### PR TITLE
feat: extend allowed parameter permutation for list systems 

### DIFF
--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -28,9 +28,7 @@ import (
 	"github.com/openkcm/registry/internal/service"
 )
 
-var (
-	ErrMissingSvrPort = errors.New("server port is missing")
-)
+var ErrMissingSvrPort = errors.New("server port is missing")
 
 func loadConfig() (*config.Config, error) {
 	cfg := &config.Config{}

--- a/integration/system_test.go
+++ b/integration/system_test.go
@@ -380,10 +380,9 @@ func TestSystemService(t *testing.T) {
 					expectedExternalID string
 				}{
 					{
-						name: "ID",
+						name: "externalID",
 						request: &systemgrpc.ListSystemsRequest{
 							ExternalId: externalID1,
-							Region:     region1,
 						},
 						expectedExternalID: externalID1,
 					},
@@ -431,7 +430,7 @@ func TestSystemService(t *testing.T) {
 						errorCode: codes.NotFound,
 					},
 					{
-						name:      "no tenantID and no externalID and region is provided in query",
+						name:      "no tenantID and no externalID is provided in query",
 						request:   &systemgrpc.ListSystemsRequest{},
 						errorCode: codes.InvalidArgument,
 					},

--- a/internal/service/system.go
+++ b/internal/service/system.go
@@ -87,7 +87,7 @@ func (s *System) RegisterSystem(ctx context.Context, in *systemgrpc.RegisterSyst
 func (s *System) ListSystems(ctx context.Context, in *systemgrpc.ListSystemsRequest) (*systemgrpc.ListSystemsResponse, error) {
 	slogctx.Debug(ctx, "ListSystems called", "external_id", in.GetExternalId(), "region", in.GetRegion(), "tenant_id", in.GetTenantId())
 
-	if (in.GetExternalId() == "" || in.GetRegion() == "") && in.GetTenantId() == "" {
+	if in.GetExternalId() == "" && in.GetTenantId() == "" {
 		return nil, ErrSystemListNotAllowed
 	}
 


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       breaking|feat|doc|build|chore|ci|docs|fix|perf|refactor|revert|style|test
- description:   <short description of the PR>

Following the conventional commits: https://www.conventionalcommits.org
-->

`ListSystems` now only need one of `tenantID` or `externalID` as a required param. Currently `ListSystem` at least needs `tenantID` or both `externalID` and `region`
