### PR TITLE
feat: remove auth

### DIFF
--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -182,7 +182,151 @@ func TestAuth(t *testing.T) {
 				assert.NoError(t, err)
 			})
 		}
+	})
 
+	t.Run("RemoveAuth", func(t *testing.T) {
+		t.Run("should return error if", func(t *testing.T) {
+			t.Run("auth does not exist", func(t *testing.T) {
+				// when
+				resp, err := subj.RemoveAuth(ctx, &authgrpc.RemoveAuthRequest{
+					ExternalId: "non-existing-auth",
+				})
+
+				// then
+				assert.Error(t, err)
+				assert.Equal(t, codes.NotFound, status.Code(err), err.Error())
+				assert.Nil(t, resp)
+			})
+
+			t.Run("auth is not in APPLIED status", func(t *testing.T) {
+				// given
+				auth := validAuth()
+				auth.Status = model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_APPLYING_ERROR.String())
+				err := repo.Create(ctx, auth)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, auth)
+					assert.NoError(t, err)
+				}()
+
+				// when
+				resp, err := subj.RemoveAuth(ctx, &authgrpc.RemoveAuthRequest{
+					ExternalId: auth.ExternalID.String(),
+				})
+
+				// then
+				assert.Error(t, err)
+				assert.Equal(t, codes.FailedPrecondition, status.Code(err), err.Error())
+				assert.Nil(t, resp)
+			})
+
+			t.Run("tenant linked to auth does not exist", func(t *testing.T) {
+				// given
+				auth := validAuth()
+				auth.TenantID = "non-existing-tenant"
+				err := repo.Create(ctx, auth)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, auth)
+					assert.NoError(t, err)
+				}()
+
+				// when
+				resp, err := subj.RemoveAuth(ctx, &authgrpc.RemoveAuthRequest{
+					ExternalId: auth.ExternalID.String(),
+				})
+
+				// then
+				assert.Error(t, err)
+				assert.Equal(t, codes.NotFound, status.Code(err), err.Error())
+				assert.Nil(t, resp)
+			})
+
+			t.Run("tenant linked to auth is not active", func(t *testing.T) {
+				// given
+				tenant := validTenant()
+				tenant.Status = model.TenantStatus(pb.Status_STATUS_BLOCKED.String())
+				err := repo.Create(ctx, tenant)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, tenant)
+					assert.NoError(t, err)
+				}()
+
+				auth := validAuth()
+				auth.TenantID = tenant.ID
+				err = repo.Create(ctx, auth)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, auth)
+					assert.NoError(t, err)
+				}()
+
+				// when
+				resp, err := subj.RemoveAuth(ctx, &authgrpc.RemoveAuthRequest{
+					ExternalId: auth.ExternalID.String(),
+				})
+
+				// then
+				assert.Error(t, err)
+				assert.Equal(t, codes.FailedPrecondition, status.Code(err), err.Error())
+				assert.Nil(t, resp)
+			})
+		})
+
+		tests := []struct {
+			name       string
+			externalID string
+			expStatus  model.AuthStatus
+		}{
+			{
+				name:       "should change status to REMOVING_ERROR if operator fails to process the request",
+				externalID: operatortest.AuthExternalIDFail,
+				expStatus:  model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_REMOVING_ERROR.String()),
+			},
+			{
+				name:       "should change status to REMOVED if operator processes the request successfully",
+				externalID: operatortest.AuthExternalIDSuccess,
+				expStatus:  model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_REMOVED.String()),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// given
+				tenant := validTenant()
+				tenant.Region = model.Region(operatortest.Region)
+				err := repo.Create(ctx, tenant)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, tenant)
+					assert.NoError(t, err)
+				}()
+
+				auth := validAuth()
+				auth.ExternalID = model.ExternalID(tt.externalID)
+				auth.TenantID = tenant.ID
+				err = repo.Create(ctx, auth)
+				assert.NoError(t, err)
+				defer func() {
+					_, err := repo.Delete(ctx, auth)
+					assert.NoError(t, err)
+				}()
+
+				// when
+				resp, err := subj.RemoveAuth(ctx, &authgrpc.RemoveAuthRequest{
+					ExternalId: tt.externalID,
+				})
+
+				// then
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.True(t, resp.Success)
+
+				err = waitForAuthReconciliation(ctx, subj, tt.externalID, tt.expStatus)
+				assert.NoError(t, err)
+			})
+		}
 	})
 }
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -112,9 +112,60 @@ func (a *Auth) GetAuth(ctx context.Context, req *authgrpc.GetAuthRequest) (*auth
 	}, nil
 }
 
+// RemoveAuth marks an auth for removal by its external ID and starts a job to remove it from the associated tenant.
+// If the auth does not exist or is not in APPLIED status, it returns an error.
+func (a *Auth) RemoveAuth(ctx context.Context, req *authgrpc.RemoveAuthRequest) (*authgrpc.RemoveAuthResponse, error) {
+	ctx = slogctx.With(ctx, "externalID", req.ExternalId)
+	slogctx.Debug(ctx, "removing auth")
+
+	err := a.repo.Transaction(ctx, func(ctx context.Context, r repository.Repository) error {
+		auth, err := getAuth(ctx, r, model.ExternalID(req.ExternalId))
+		if err != nil {
+			return err
+		}
+
+		if auth.Status != model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_APPLIED.String()) {
+			slogctx.Error(ctx, AuthInvalidStatusMsg, "status", auth.Status)
+			return ErrorWithParams(ErrAuthInvalidStatus, "status", auth.Status)
+		}
+
+		err = a.validateActiveTenant(ctx, r, auth.TenantID)
+		if err != nil {
+			slogctx.Error(ctx, "tenant is invalid or not active", "error", err)
+			return err
+		}
+
+		err = patchAuth(ctx, r,
+			model.ExternalID(req.ExternalId),
+			func(auth *model.Auth) {
+				auth.Status = model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_REMOVING.String())
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		err = a.prepareJob(ctx, auth, authgrpc.AuthAction_AUTH_ACTION_REMOVE_AUTH.String())
+		if err != nil {
+			slogctx.Error(ctx, "failed to prepare job", "error", err)
+			return err
+		}
+
+		return nil
+	})
+	err = mapError(err)
+	if err != nil {
+		return nil, err
+	}
+
+	return &authgrpc.RemoveAuthResponse{
+		Success: true,
+	}, nil
+}
+
 // ConfirmJob confirms that the auth associated with the job exists.
 func (a *Auth) ConfirmJob(ctx context.Context, job orbital.Job) (orbital.JobConfirmResult, error) {
-	_, err := getAuth(ctx, a.repo, model.ExternalID(job.ExternalID))
+	auth, err := getAuth(ctx, a.repo, model.ExternalID(job.ExternalID))
 	if err != nil {
 		slogctx.Error(ctx, "failed to get auth for job confirmation", "error", err)
 		return orbital.JobConfirmResult{}, err
@@ -122,6 +173,15 @@ func (a *Auth) ConfirmJob(ctx context.Context, job orbital.Job) (orbital.JobConf
 
 	switch job.Type {
 	case authgrpc.AuthAction_AUTH_ACTION_APPLY_AUTH.String():
+		return orbital.JobConfirmResult{Done: true}, nil
+	case authgrpc.AuthAction_AUTH_ACTION_REMOVE_AUTH.String():
+		if auth.Status != model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_REMOVING.String()) {
+			slogctx.Error(ctx, AuthInvalidStatusMsg, "status", auth.Status)
+			return orbital.JobConfirmResult{
+				IsCanceled:           true,
+				CanceledErrorMessage: fmt.Sprintf("%s: status=%s", ErrAuthInvalidStatus, auth.Status),
+			}, nil
+		}
 		return orbital.JobConfirmResult{Done: true}, nil
 	default:
 		slogctx.Error(ctx, "unexpected job type for auth")
@@ -174,10 +234,21 @@ func (a *Auth) ResolveTasks(ctx context.Context, job orbital.Job, targetsByRegio
 
 // HandleJobDone updates the auth status to APPLIED when the job is done.
 func (a *Auth) HandleJobDone(ctx context.Context, job orbital.Job) error {
+	var status authgrpc.AuthStatus
+	switch job.Type {
+	case authgrpc.AuthAction_AUTH_ACTION_APPLY_AUTH.String():
+		status = authgrpc.AuthStatus_AUTH_STATUS_APPLIED
+	case authgrpc.AuthAction_AUTH_ACTION_REMOVE_AUTH.String():
+		status = authgrpc.AuthStatus_AUTH_STATUS_REMOVED
+	default:
+		slogctx.Error(ctx, ErrUnexpectedJobType.Error(), "jobType", job.Type)
+		return nil
+	}
+
 	err := patchAuth(ctx, a.repo,
 		model.ExternalID(job.ExternalID),
 		func(auth *model.Auth) {
-			auth.Status = model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_APPLIED.String())
+			auth.Status = model.AuthStatus(status.String())
 		},
 	)
 	if errors.Is(err, ErrAuthNotFound) {
@@ -224,10 +295,21 @@ func (a *Auth) prepareJob(ctx context.Context, auth *model.Auth, jobType string)
 }
 
 func (a *Auth) handleJobAborted(ctx context.Context, job orbital.Job) error {
+	var status authgrpc.AuthStatus
+	switch job.Type {
+	case authgrpc.AuthAction_AUTH_ACTION_APPLY_AUTH.String():
+		status = authgrpc.AuthStatus_AUTH_STATUS_APPLYING_ERROR
+	case authgrpc.AuthAction_AUTH_ACTION_REMOVE_AUTH.String():
+		status = authgrpc.AuthStatus_AUTH_STATUS_REMOVING_ERROR
+	default:
+		slogctx.Error(ctx, ErrUnexpectedJobType.Error(), "jobType", job.Type)
+		return nil
+	}
+
 	err := patchAuth(ctx, a.repo,
 		model.ExternalID(job.ExternalID),
 		func(auth *model.Auth) {
-			auth.Status = model.AuthStatus(authgrpc.AuthStatus_AUTH_STATUS_APPLYING_ERROR.String())
+			auth.Status = model.AuthStatus(status.String())
 			auth.ErrorMessage = job.ErrorMessage
 		},
 	)

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -233,7 +233,7 @@ func (a *Auth) ResolveTasks(ctx context.Context, job orbital.Job, targetsByRegio
 	}, nil
 }
 
-// HandleJobDone updates the auth status to APPLIED when the job is done.
+// HandleJobDone updates auth when the job is done.
 func (a *Auth) HandleJobDone(ctx context.Context, job orbital.Job) error {
 	var status authgrpc.AuthStatus
 	switch job.Type {
@@ -259,12 +259,12 @@ func (a *Auth) HandleJobDone(ctx context.Context, job orbital.Job) error {
 	return err
 }
 
-// HandleJobCanceled updates the auth status to APPLYING_ERROR when the job is canceled.
+// HandleJobCanceled updates auth when the job is canceled.
 func (a *Auth) HandleJobCanceled(ctx context.Context, job orbital.Job) error {
 	return a.handleJobAborted(ctx, job)
 }
 
-// HandleJobFailed updates the auth status to APPLYING_ERROR when the job has failed.
+// HandleJobFailed updates auth when the job is failed.
 func (a *Auth) HandleJobFailed(ctx context.Context, job orbital.Job) error {
 	return a.handleJobAborted(ctx, job)
 }

--- a/internal/service/error.go
+++ b/internal/service/error.go
@@ -33,6 +33,7 @@ const (
 	UpdateAuthErrMsg     = "could not update auth"
 	AuthNotFoundErrMsg   = "auth not found"
 	AuthAlreadyExistsMsg = "auth with the given external ID already exists"
+	AuthInvalidStatusMsg = "invalid auth status"
 )
 
 const (
@@ -73,6 +74,7 @@ var (
 	ErrAuthUpdate        = status.Error(codes.Internal, UpdateAuthErrMsg)
 	ErrAuthNotFound      = status.Error(codes.NotFound, AuthNotFoundErrMsg)
 	ErrAuthAlreadyExists = status.Error(codes.AlreadyExists, AuthAlreadyExistsMsg)
+	ErrAuthInvalidStatus = status.Error(codes.FailedPrecondition, AuthInvalidStatusMsg)
 )
 
 var (


### PR DESCRIPTION
<!-- Format of PR Title: <category>: <description>
Possible values:
- category:       feat
- description:   remove auth

Following the conventional commits: https://www.conventionalcommits.org
-->

**What this PR does / why we need it**:
This implements the gRPC method `RemoveAuth`, which includes validations for auth existence, auth status, tenant existence, and tenant status.
