### PR TITLE
feat: return grpc status already_exists for RegisterSystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openkcm/registry
 
-go 1.25.6
-
-toolchain go1.26.1
+go 1.26.1
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/internal/model/auth_test.go
+++ b/internal/model/auth_test.go
@@ -41,8 +41,7 @@ func TestAuthValidationIDs(t *testing.T) {
 	authType := reflect.TypeFor[model.Auth]()
 
 	var tagValidationIDs []string
-	for i := range authType.NumField() {
-		field := authType.Field(i)
+	for field := range authType.Fields() {
 		if validationID := field.Tag.Get(validation.TagName); validationID != "" {
 			tagValidationIDs = append(tagValidationIDs, validationID)
 		}

--- a/internal/service/system.go
+++ b/internal/service/system.go
@@ -10,6 +10,8 @@ import (
 
 	systemgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/system/v1"
 	slogctx "github.com/veqryn/slog-context"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/openkcm/registry/internal/model"
 	"github.com/openkcm/registry/internal/repository"
@@ -36,6 +38,8 @@ func NewSystem(repo repository.Repository, meters *Meters, validation *validatio
 }
 
 // RegisterSystem handles the creation of a new System. The response contains the created System's ID.
+//
+//nolint:cyclop
 func (s *System) RegisterSystem(ctx context.Context, in *systemgrpc.RegisterSystemRequest) (*systemgrpc.RegisterSystemResponse, error) {
 	slogctx.Debug(ctx, "RegisterSystem called", "externalId", in.GetExternalId(), "region", in.GetRegion(), "tenantId", in.GetTenantId(), "systemType", in.GetType(), "status", in.GetStatus().String())
 
@@ -78,6 +82,10 @@ func (s *System) RegisterSystem(ctx context.Context, in *systemgrpc.RegisterSyst
 
 		return r.Create(ctx, regionalSystem)
 	}); err != nil {
+		if _, ok := errors.AsType[*repository.UniqueConstraintError](err); ok {
+			return nil, grpcstatus.Error(grpccodes.AlreadyExists, "system already exists")
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR makes the RegisterSystem method return a gRPC status already_exists if the system already exists

feat: return grpc status already_exists for RegisterSystem