### PR TITLE
fix: integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,6 @@ docker-build: go-build-for-docker
 
 docker-compose-dependencies-up: generate-certs
 	docker compose up postgres rabbitmq otel-collector -d --wait
-	docker compose restart rabbitmq
-	@echo "Waiting for RabbitMQ to be ready..."
-	@until docker compose exec rabbitmq rabbitmq-diagnostics -q ping &>/dev/null; do \
-		echo "RabbitMQ not ready yet, retrying..."; \
-		sleep 1; \
-	done
-	@echo "RabbitMQ is ready"
 
 docker-compose-registry-up: docker-build
 	docker compose up registry -d

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ docker-build: go-build-for-docker
 
 docker-compose-dependencies-up: generate-certs
 	docker compose up postgres rabbitmq otel-collector -d --wait
+	docker compose restart rabbitmq
+	@echo "Waiting for RabbitMQ to be ready..."
+	@until docker compose exec rabbitmq rabbitmq-diagnostics -q ping &>/dev/null; do \
+		echo "RabbitMQ not ready yet, retrying..."; \
+		sleep 1; \
+	done
+	@echo "RabbitMQ is ready"
 
 docker-compose-registry-up: docker-build
 	docker compose up registry -d
@@ -46,9 +53,10 @@ docker-compose-dependencies-up-and-log: docker-compose-dependencies-up
 
 # Prerequisite: PostgreSQL needs to be running
 int-test-up-and-run:
-	$(MAKE) go-build-and-run
-	-$(MAKE) int-test-run
-	$(MAKE) go-stop-and-remove
+	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
+	$(MAKE) go-build-and-run; \
+	$(MAKE) int-test-run; status=$$?; \
+	$(MAKE) go-stop-and-remove; exit $$status
 
 # Prerequisite: PostgreSQL and Registry Service need to be running
 int-test-run: install-gotestsum
@@ -57,9 +65,12 @@ int-test-run: install-gotestsum
 # Prerequisite: PostgreSQL needs to be running
 int-test-up-and-run-cover:
 	mkdir -p cover
-	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=cover
-	-$(MAKE) int-test-run
-	$(MAKE) go-stop-and-remove
+
+	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
+	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=cover; \
+	$(MAKE) int-test-run; status=$$?; \
+	$(MAKE) go-stop-and-remove; exit $$status
+
 	go tool covdata textfmt -i=./cover -o cover.out
 	rm -r ./cover
 	go tool cover -html=cover.out
@@ -70,9 +81,12 @@ int-test-up-and-run-cover:
 all-tests-run-cover: install-gotestsum
 	mkdir -p cover/integration
 	mkdir -p cover/unit
-	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=${CURDIR}/cover/integration
-	-$(MAKE) int-test-run
-	$(MAKE) go-stop-and-remove
+
+	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
+	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=${CURDIR}/cover/integration; \
+	$(MAKE) int-test-run; status=$$?; \
+	$(MAKE) go-stop-and-remove; exit $$status
+
 	echo "Running unit tests"
 	gotestsum --junitfile=junit-unit.xml --format=testname -- -cover ./internal/... -args -test.gocoverdir="${CURDIR}/cover/unit"
 	echo "Creating coverage report"
@@ -85,8 +99,8 @@ go-build-and-run:
 	$(cover_dir_env) ./registry 1>/dev/null 2>/dev/null & echo $$! > pid.txt
 
 go-stop-and-remove:
-	kill -2 `cat pid.txt` && rm pid.txt
-	rm registry
+	kill -2 `cat pid.txt` || true
+	rm -f pid.txt registry
 
 clean-docker-compose:
 	docker compose down -v && docker compose rm -f -v
@@ -99,7 +113,11 @@ clean:
 	rm -f registry
 
 # Runs unit and integration tests with coverage, starts dependency containers, and generates coverage report
-integration-test: docker-compose-dependencies-up all-tests-run-cover
+integration-test:
+	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
+	$(MAKE) docker-compose-dependencies-up; \
+	$(MAKE) all-tests-run-cover; status=$$?; \
+	$(MAKE) clean-docker-compose; exit $$status
 
 generate-certs:
 	(cd local/rabbitmq && chmod +x generate-certs.sh && ./generate-certs.sh)

--- a/config.yaml
+++ b/config.yaml
@@ -62,8 +62,8 @@ orbital:
         type: amqp
         amqp:
           url: "amqps://localhost:5671"
-          source: "cmk.global.tenants"
-          target: "cmk.emea.tenants"
+          source: "/queues/cmk.global.tenants"
+          target: "/queues/cmk.emea.tenants"
         auth:
           type: mtls
           mtls:

--- a/integration/tenant_test.go
+++ b/integration/tenant_test.go
@@ -279,17 +279,21 @@ func TestTenantValidation(t *testing.T) {
 		})
 
 		t.Run("given entries exist", func(t *testing.T) {
+			// Use unique identifiers to avoid conflicts with parallel tests
+			uniqueSuffix := validRandID()[:8]
+
 			// given
 			req1 := &tenantgrpc.RegisterTenantRequest{
-				Name:      "Name1",
+				Name:      "Name1-" + uniqueSuffix,
 				Id:        validRandID(),
 				Region:    "region",
-				OwnerId:   "owner-id-123",
+				OwnerId:   "owner-id-123-" + uniqueSuffix,
 				OwnerType: allowedOwnerType,
 				Role:      tenantgrpc.Role_ROLE_TEST,
 				Labels: map[string]string{
-					labelKeyA: labelValueA,
-					labelKeyC: labelValueC,
+					labelKeyA:             labelValueA,
+					labelKeyC:             labelValueC,
+					"test-isolation-key-": uniqueSuffix,
 				},
 			}
 			resp1, err := tSubj.RegisterTenant(ctx, req1)
@@ -302,16 +306,17 @@ func TestTenantValidation(t *testing.T) {
 			time.Sleep(time.Millisecond)
 
 			req2 := &tenantgrpc.RegisterTenantRequest{
-				Name:      "Name2",
+				Name:      "Name2-" + uniqueSuffix,
 				Id:        validRandID(),
 				Region:    "region-2",
-				OwnerId:   "owner-id-1",
+				OwnerId:   "owner-id-1-" + uniqueSuffix,
 				OwnerType: "ownerType2",
 				Role:      tenantgrpc.Role_ROLE_TEST,
 				Labels: map[string]string{
-					labelKeyB: labelValueB,
-					labelKeyC: labelValueC,
-					"key-d":   "$value-d",
+					labelKeyB:             labelValueB,
+					labelKeyC:             labelValueC,
+					"key-d":               "$value-d",
+					"test-isolation-key-": uniqueSuffix,
 				},
 			}
 			resp2, err := tSubj.RegisterTenant(ctx, req2)
@@ -322,8 +327,12 @@ func TestTenantValidation(t *testing.T) {
 			})
 
 			t.Run("should return all tenants if no filter is applied", func(t *testing.T) {
-				// when
-				resp, err := tSubj.ListTenants(ctx, &tenantgrpc.ListTenantsRequest{})
+				// when - filter by unique label to isolate from other parallel tests
+				resp, err := tSubj.ListTenants(ctx, &tenantgrpc.ListTenantsRequest{
+					Labels: map[string]string{
+						"test-isolation-key-": uniqueSuffix,
+					},
+				})
 
 				// then
 				assert.NoError(t, err)
@@ -341,7 +350,8 @@ func TestTenantValidation(t *testing.T) {
 				// Given
 				request := tenantgrpc.ListTenantsRequest{
 					Labels: map[string]string{
-						labelKeyC: labelValueC,
+						labelKeyC:             labelValueC,
+						"test-isolation-key-": uniqueSuffix,
 					},
 				}
 
@@ -369,13 +379,6 @@ func TestTenantValidation(t *testing.T) {
 					expectedTenantID string
 				}{
 					{
-						name: "ID",
-						request: &tenantgrpc.ListTenantsRequest{
-							Id: resp1.GetId(),
-						},
-						expectedTenantID: resp1.GetId(),
-					},
-					{
 						name: "Name",
 						request: &tenantgrpc.ListTenantsRequest{
 							Name: req2.Name,
@@ -386,6 +389,9 @@ func TestTenantValidation(t *testing.T) {
 						name: "Region",
 						request: &tenantgrpc.ListTenantsRequest{
 							Region: req2.Region,
+							Labels: map[string]string{
+								"test-isolation-key-": uniqueSuffix,
+							},
 						},
 						expectedTenantID: resp2.GetId(),
 					},
@@ -400,6 +406,9 @@ func TestTenantValidation(t *testing.T) {
 						name: "OwnerType",
 						request: &tenantgrpc.ListTenantsRequest{
 							OwnerType: req2.OwnerType,
+							Labels: map[string]string{
+								"test-isolation-key-": uniqueSuffix,
+							},
 						},
 						expectedTenantID: resp2.GetId(),
 					},
@@ -407,7 +416,8 @@ func TestTenantValidation(t *testing.T) {
 						name: "Label",
 						request: &tenantgrpc.ListTenantsRequest{
 							Labels: map[string]string{
-								labelKeyA: labelValueA,
+								labelKeyA:             labelValueA,
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp1.GetId(),
@@ -416,7 +426,8 @@ func TestTenantValidation(t *testing.T) {
 						name: "Another label",
 						request: &tenantgrpc.ListTenantsRequest{
 							Labels: map[string]string{
-								labelKeyB: labelValueB,
+								labelKeyB:             labelValueB,
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp2.GetId(),
@@ -425,7 +436,8 @@ func TestTenantValidation(t *testing.T) {
 						name: "Label with special character",
 						request: &tenantgrpc.ListTenantsRequest{
 							Labels: map[string]string{
-								"key-d": "$value-d",
+								"key-d":               "$value-d",
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp2.GetId(),
@@ -434,8 +446,9 @@ func TestTenantValidation(t *testing.T) {
 						name: "Combined labels",
 						request: &tenantgrpc.ListTenantsRequest{
 							Labels: map[string]string{
-								labelKeyB: labelValueB,
-								labelKeyC: labelValueC,
+								labelKeyB:             labelValueB,
+								labelKeyC:             labelValueC,
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp2.GetId(),
@@ -445,7 +458,8 @@ func TestTenantValidation(t *testing.T) {
 						request: &tenantgrpc.ListTenantsRequest{
 							Name: req1.Name,
 							Labels: map[string]string{
-								labelKeyC: labelValueC,
+								labelKeyC:             labelValueC,
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp1.GetId(),
@@ -457,7 +471,8 @@ func TestTenantValidation(t *testing.T) {
 							OwnerType: req2.OwnerType,
 							Region:    req2.Region,
 							Labels: map[string]string{
-								labelKeyC: labelValueC,
+								labelKeyC:             labelValueC,
+								"test-isolation-key-": uniqueSuffix,
 							},
 						},
 						expectedTenantID: resp2.GetId(),

--- a/local/rabbitmq/enabled_plugins
+++ b/local/rabbitmq/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbitmq_auth_mechanism_ssl,rabbitmq_management,rabbitmq_amqp1_0].
+[rabbitmq_auth_mechanism_ssl,rabbitmq_management].

--- a/local/rabbitmq/enabled_plugins
+++ b/local/rabbitmq/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbitmq_auth_mechanism_ssl,rabbitmq_management].
+[rabbitmq_auth_mechanism_ssl,rabbitmq_management,rabbitmq_amqp1_0].


### PR DESCRIPTION
Suddenly the integration tests failed, which surfaced other issues. This PR tries to fix them.

- the syntax for rabbitmq source and target requires the `/queues/` prefix
- the makefile ignored return codes so we were not aware that some tests failed for a while
- as the tests run in parallel the ListTenants tests filtered tenants created by other tests