### PR TITLE
fix(helm): make image.tag or image.digest mandatory

### DIFF
--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -5,7 +5,7 @@ name: registry
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/registry/templates/_helpers.tpl
+++ b/charts/registry/templates/_helpers.tpl
@@ -76,11 +76,12 @@ Create the name of the service account to use
 
 {{/*
 Util function for generating the image URL based on the provided options.
+Either image.tag or image.digest must be set explicitly; no fallback to appVersion.
 */}}
 {{- define "registry.image" -}}
-{{- $defaultTag := index . 1 -}}
 {{- with index . 0 -}}
+{{- if not (or .digest .tag) -}}{{ fail "Either image.tag or image.digest must be set" }}{{- end -}}
 {{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
-{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" .tag }}{{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ template "registry.image" (tuple .Values.image $.Chart.AppVersion) }}"
+          image: "{{ template "registry.image" (tuple .Values.image) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.image.command }}
           command: ["{{- toYaml . }}"]

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -35,9 +35,8 @@ image:
   repository: images/registry
 
   # Override the image tag to deploy by setting this variable.
-  # If no value is set, the chart's appVersion is used.
   # +docs:property
-  # tag: 0.0.1
+  tag: latest
 
   # Setting a digest will override any tag.
   # +docs:property

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -36,7 +36,7 @@ image:
 
   # Override the image tag to deploy by setting this variable.
   # +docs:property
-  tag: latest
+  # tag: 0.0.1
 
   # Setting a digest will override any tag.
   # +docs:property


### PR DESCRIPTION
## Summary
- Removes the silent fallback to `appVersion` in the image helper
- Deployments without an explicit `image.tag` or `image.digest` now fail at render time with a clear error instead of silently using whatever `appVersion` is set to
- If both `image.tag` and `image.digest` are provided, digest takes precedence (unchanged behaviour)
- Bumps chart patch version