### PR TITLE
fix: more on flaky integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,15 +95,15 @@ go-build-and-run:
 # Waits for the registry service to be ready by polling the gRPC health endpoint
 wait-for-registry:
 	@echo "Waiting for registry service to be ready..."
-	@for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do \
+	@for i in $$(seq 1 45); do \
 		if go tool github.com/grpc-ecosystem/grpc-health-probe -addr=localhost:9092 2>/dev/null; then \
 			echo "Registry service is ready"; \
 			exit 0; \
 		fi; \
-		echo "Waiting... ($$i/20)"; \
+		echo "Waiting... ($$i/45)"; \
 		sleep 1; \
 	done; \
-	echo "Registry service failed to start within 20 seconds"; \
+	echo "Registry service failed to start within 45 seconds"; \
 	exit 1
 
 go-stop-and-remove:

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -351,15 +351,21 @@ func TestAuth(t *testing.T) {
 }
 
 func waitForAuthReconciliation(ctx context.Context, subj authgrpc.ServiceClient, externalID, expStatus string) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	timeout := getReconciliationTimeout()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var currentAuth *authgrpc.Auth
+	backoff := getInitialPollInterval()
+	startTime := time.Now()
+	attempts := 0
+
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("%w: auth: %s", ctx.Err(), currentAuth)
+			return fmt.Errorf("%w after %v (%d attempts); auth: %s", ctx.Err(), time.Since(startTime), attempts, currentAuth)
 		default:
+			attempts++
 			resp, err := subj.GetAuth(ctx, &authgrpc.GetAuthRequest{
 				ExternalId: externalID,
 			})
@@ -372,7 +378,10 @@ func waitForAuthReconciliation(ctx context.Context, subj authgrpc.ServiceClient,
 
 			currentAuth = resp.Auth
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(backoff)
+		if backoff < maxPollInterval {
+			backoff = min(backoff*2, maxPollInterval)
+		}
 	}
 }
 

--- a/integration/tenant_reconciliation_test.go
+++ b/integration/tenant_reconciliation_test.go
@@ -265,15 +265,21 @@ func TestTenantReconciliation(t *testing.T) {
 }
 
 func waitForTenantReconciliation(ctx context.Context, tSubj tenantgrpc.ServiceClient, tenantID string, expState expStateFunc) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	timeout := getReconciliationTimeout()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var currentTenant *tenantgrpc.Tenant
+	backoff := getInitialPollInterval()
+	startTime := time.Now()
+	attempts := 0
+
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("%w; tenant: %s", ctx.Err(), currentTenant)
+			return fmt.Errorf("%w after %v (%d attempts); tenant: %s", ctx.Err(), time.Since(startTime), attempts, currentTenant)
 		default:
+			attempts++
 			resp, err := tSubj.GetTenant(ctx, &tenantgrpc.GetTenantRequest{
 				Id: tenantID,
 			})
@@ -286,6 +292,9 @@ func waitForTenantReconciliation(ctx context.Context, tSubj tenantgrpc.ServiceCl
 
 			currentTenant = resp.GetTenant()
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(backoff)
+		if backoff < maxPollInterval {
+			backoff = min(backoff*2, maxPollInterval)
+		}
 	}
 }

--- a/integration/testconfig_test.go
+++ b/integration/testconfig_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+// +build integration
+
+package integration_test
+
+import (
+	"os"
+	"time"
+)
+
+// getReconciliationTimeout returns an appropriate timeout for reconciliation waits.
+// In CI environments, we use a longer timeout to account for resource contention.
+func getReconciliationTimeout() time.Duration {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
+		return 45 * time.Second
+	}
+	return 15 * time.Second
+}
+
+// getInitialPollInterval returns the starting poll interval for reconciliation checks.
+func getInitialPollInterval() time.Duration {
+	if os.Getenv("CI") != "" || os.Getenv("GITHUB_ACTIONS") != "" {
+		return 200 * time.Millisecond
+	}
+	return 100 * time.Millisecond
+}
+
+// maxPollInterval is the maximum interval for exponential backoff in reconciliation polling.
+const maxPollInterval = 2 * time.Second


### PR DESCRIPTION
#185 did not solve the issue. This now hopefully fixes the breaking workflows like [this](https://github.com/openkcm/registry/actions/runs/27423257682/job/81054158027) with error `context deadline exceeded`.
This time the [tests](https://github.com/openkcm/registry/actions/runs/27424939076) ran fine for five times.