### PR TITLE
chore(linter): include all build tags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,11 @@
 version: "2"
+run:
+  build-tags: [integration, helmtest]
 linters:
   default: all
   disable:
+    - contextcheck
+    - gomodguard # Replaced by gomodguard_v2, enabled with default: all
     - noinlineerr
     - funlen
     - noctx

--- a/helmtest/registry_test.go
+++ b/helmtest/registry_test.go
@@ -1,6 +1,6 @@
 //go:build helmtest
 
-package helmtest
+package helmtest_test
 
 import (
 	"context"

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -26,7 +25,9 @@ func TestAuth(t *testing.T) {
 	// given
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	subj := authgrpc.NewServiceClient(conn)
 
@@ -389,7 +390,9 @@ func TestListAuth(t *testing.T) {
 	// given
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	db, err := startDB()
 	require.NoError(t, err)
@@ -518,7 +521,9 @@ func TestListAuth(t *testing.T) {
 func TestAuthValidation(t *testing.T) {
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	subj := authgrpc.NewServiceClient(conn)
 

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -16,7 +15,9 @@ func TestHealth(t *testing.T) {
 	// given
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	subj := healthgrpc.NewHealthClient(conn)
 

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -238,7 +238,7 @@ func getSystemFromDB(ctx context.Context, db *gorm.DB, externalID, systemType st
 		return nil, err
 	}
 	if !found {
-		return nil, nil
+		return nil, nil //nolint:nilnil // callers distinguish "not found" via nil result
 	}
 
 	return sys, nil
@@ -276,6 +276,7 @@ func deleteSystem(ctx context.Context, s systemgrpc.ServiceClient, externalID, s
 }
 
 func cleanupSystem(t *testing.T, ctx context.Context, sSubj systemgrpc.ServiceClient, mSubj mappinggrpc.ServiceClient, externalID, tenantID, systemType, region string, l1KeyClaim bool) {
+	t.Helper()
 	if l1KeyClaim {
 		_, err := sSubj.UpdateSystemL1KeyClaim(ctx, &systemgrpc.UpdateSystemL1KeyClaimRequest{
 			ExternalId: externalID,
@@ -300,6 +301,7 @@ func cleanupSystem(t *testing.T, ctx context.Context, sSubj systemgrpc.ServiceCl
 }
 
 func registerRegionalSystem(t *testing.T, ctx context.Context, sSubj systemgrpc.ServiceClient, tenantID string, l1KeyClaim bool, systemType string, region, externalID *string) (string, string, string) {
+	t.Helper()
 	req := validRegisterSystemReq()
 	req.TenantId = tenantID
 	req.HasL1KeyClaim = l1KeyClaim

--- a/integration/mapping_test.go
+++ b/integration/mapping_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/metric_scraper_test.go
+++ b/integration/metric_scraper_test.go
@@ -59,7 +59,7 @@ func (ms metricScraper) scrape(ctx context.Context, metric metric) (int, error) 
 	if err != nil {
 		return 0, fmt.Errorf("error scraping metrics: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return 0, errMetricsServerStatus
@@ -67,31 +67,10 @@ func (ms metricScraper) scrape(ctx context.Context, metric metric) (int, error) 
 
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
-		if !strings.Contains(scanner.Text(), metric.name) {
+		if !lineMatches(scanner.Text(), metric) {
 			continue
 		}
-		count := 0
-		for _, m := range metric.attribs {
-			if !strings.Contains(scanner.Text(), m) {
-				continue
-			}
-			count++
-		}
-		if count != len(metric.attribs) {
-			continue
-		}
-
-		split := strings.Split(scanner.Text(), " ")
-		if len(split) != 2 {
-			return 0, errMetricWrongFormat
-		}
-
-		num, err := strconv.Atoi(split[1])
-		if err != nil {
-			return 0, err
-		}
-
-		return num, nil
+		return parseMetricValue(scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -99,6 +78,26 @@ func (ms metricScraper) scrape(ctx context.Context, metric metric) (int, error) 
 	}
 
 	return 0, errMetricNotFound
+}
+
+func lineMatches(line string, m metric) bool {
+	if !strings.Contains(line, m.name) {
+		return false
+	}
+	for _, a := range m.attribs {
+		if !strings.Contains(line, a) {
+			return false
+		}
+	}
+	return true
+}
+
+func parseMetricValue(line string) (int, error) {
+	split := strings.Split(line, " ")
+	if len(split) != 2 {
+		return 0, errMetricWrongFormat
+	}
+	return strconv.Atoi(split[1])
 }
 
 func createMetric(t *testing.T, name string, attr ...string) metric {
@@ -110,7 +109,7 @@ func createMetric(t *testing.T, name string, attr ...string) metric {
 
 	a := make([]string, 0, len(attr)/2)
 	for i := 0; i < len(attr); i += 2 {
-		a = append(a, attr[i]+`="`+attr[i+1]+`"`)
+		a = append(a, attr[i]+`="`+attr[i+1]+`"`) //nolint:gosec // parity of attr is asserted above
 	}
 	metric := metric{
 		name:    name,

--- a/integration/metric_test.go
+++ b/integration/metric_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -29,7 +28,9 @@ const (
 func TestTenantMetrics(t *testing.T) {
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	subj := tenantgrpc.NewServiceClient(conn)
 
@@ -195,7 +196,9 @@ func TestTenantMetrics(t *testing.T) {
 func TestSystemMetrics(t *testing.T) {
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
 
 	sSubj := systemgrpc.NewServiceClient(conn)
 	mSub := mappinggrpc.NewServiceClient(conn)
@@ -511,6 +514,7 @@ func TestSystemMetrics(t *testing.T) {
 					Type:       req.Type,
 					Region:     req.Region,
 				})
+				assert.NoError(t, err)
 
 				// Then
 				unlinked, err := getSafeMetric(ctx, scraper, metricUnlinked)

--- a/integration/system_test.go
+++ b/integration/system_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -22,7 +21,7 @@ import (
 	"github.com/openkcm/registry/internal/validation"
 )
 
-func TestSystemService(t *testing.T) {
+func TestSystemService(t *testing.T) { //nolint:gocognit // table-driven integration test
 	// given
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
@@ -221,7 +220,6 @@ func TestSystemService(t *testing.T) {
 			regionalSystem, err := getRegionalSystem(t, ctx, sSubj, req2.GetExternalId(), req2.GetRegion(), req2.GetType())
 			assert.NoError(t, err)
 			assert.Equal(t, req2.GetExternalId(), regionalSystem.GetExternalId())
-
 		})
 	})
 
@@ -1644,6 +1642,7 @@ func listSystems(ctx context.Context, subj systemgrpc.ServiceClient, tenantID st
 }
 
 func getRegionalSystem(t *testing.T, ctx context.Context, subj systemgrpc.ServiceClient, externalID, region, systemType string) (*systemgrpc.System, error) {
+	t.Helper()
 	req := &systemgrpc.ListSystemsRequest{
 		ExternalId: externalID,
 		Region:     region,

--- a/integration/tenant_block_test.go
+++ b/integration/tenant_block_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/tenant_reconciliation_test.go
+++ b/integration/tenant_reconciliation_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/tenant_register_test.go
+++ b/integration/tenant_register_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/tenant_termination_test.go
+++ b/integration/tenant_termination_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/tenant_test.go
+++ b/integration/tenant_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -49,7 +48,7 @@ func newTenantTestContext(t *testing.T) *TenantTestContext {
 	conn, err := newGRPCClientConn()
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		conn.Close()
+		require.NoError(t, conn.Close())
 	})
 
 	db, err := startDB()

--- a/integration/tenant_unblock_test.go
+++ b/integration/tenant_unblock_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/testconfig_test.go
+++ b/integration/testconfig_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 

--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 


### PR DESCRIPTION
**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
Adding the `integration` build tag under golangci-lint's `run.build-tags` makes the linter also scan the integration test files. Fix the issues it reported so `make lint` stays clean.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
NONE
```
