### PR TITLE
fix: support patch for ApplyAuth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,4 @@ jobs:
     with:
       run_task_tests: false
       run_makefile_tests: true
-      makefile_test_name: integration-test
+      makefile_test_name: test

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -52,8 +52,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run integration tests
-        run: make integration-test
+      - name: Run tests
+        run: make test
 
       - name: Upload coverage report
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,23 +16,22 @@ A separate `Auth` and `Mapping` gRPC API live alongside these. All four are regi
 Tests use `gotestsum` (auto-installed via the Makefile target into `$GOPATH/bin`).
 
 ```sh
-# Unit tests + coverage report (writes cover.out, junit.xml)
+# Full test suite: brings up Postgres + RabbitMQ + otel-collector, builds the
+# registry binary with coverage, runs unit + integration tests, merges coverage
+# into cover.out + cover.html, and tears everything down (even on failure/Ctrl-C).
+# Writes junit-unit.xml and junit-integration.xml.
 make test
-make test-cover                       # opens HTML coverage in browser
 
 # Lint (golangci-lint, --fix enabled)
 make lint
 
-# Single test
+# Single unit test
 go test -run TestName ./internal/service/...
 go test -run TestName/subtest ./internal/...
 
-# Integration tests — require Postgres + RabbitMQ + otel-collector + a running registry binary
-make docker-compose-dependencies-up   # bring up deps only
-make int-test-up-and-run              # builds registry, starts it, runs ./integration/... with -tags=integration, tears down
-make integration-test                 # full pipeline: deps up → unit + integration with merged coverage → deps down
-
-# Single integration test (deps and registry must already be up)
+# Single integration test (bring up deps + registry yourself first)
+make docker-compose-dependencies-up
+go run ./cmd/registry/main.go &
 go test -tags=integration -run TestName ./integration/...
 
 # Helm chart tests (needs a running k8s cluster)
@@ -45,7 +44,7 @@ go run ./cmd/registry/main.go         # reads ./config.yaml or /etc/registry/con
 make docker-compose-up
 ```
 
-`make integration-test` is what CI runs end-to-end; reach for it when changes touch service/repository/orbital wiring.
+`make test` is what CI runs end-to-end; reach for it when changes touch service/repository/orbital wiring.
 
 `make compile-servicetest-pb` regenerates the protobuf used only by `internal/interceptor/servicetest`. Domain protos live in the external `github.com/openkcm/api-sdk` module — not in this repo.
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,63 @@
-.PHONY: default test
+.PHONY: default test lint clean helm-test helm-install-dependencies helm-uninstall-dependencies helm-install-registry helm-uninstall-registry
 
 default: test
 
-test: install-gotestsum
-	rm -f cover.* junit.xml
-	env TEST_ENV=make gotestsum --format testname --junitfile junit.xml -- -coverprofile cover.out ./internal/...
-
-test-cover: test
-	go tool cover -html=cover.out
+# Runs unit + integration tests end-to-end:
+#   1. brings up dependencies (postgres, rabbitmq, otel-collector)
+#   2. builds the registry binary with coverage instrumentation and starts it
+#   3. runs unit tests (./internal/...) with coverage into cover/unit
+#   4. runs integration tests (./integration/... -tags=integration) against the running binary
+#   5. stops the registry, merges unit + integration coverage into cover.out + cover.html
+# Everything is torn down (registry process, docker compose stack, temp files) via a trap
+# regardless of whether the recipe succeeded, failed, or was interrupted.
+test: install-gotestsum generate-certs
+	@rm -rf cover cover.out cover.html junit-unit.xml junit-integration.xml registry pid.txt
+	@mkdir -p cover/unit cover/integration
+	@set -u; \
+	cleanup() { \
+	  status=$$?; \
+	  trap - EXIT INT TERM; \
+	  echo "==> Tearing down"; \
+	  if [ -f pid.txt ]; then \
+	    kill -2 "$$(cat pid.txt)" 2>/dev/null || true; \
+	    wait "$$(cat pid.txt)" 2>/dev/null || true; \
+	    rm -f pid.txt; \
+	  fi; \
+	  rm -f registry; \
+	  rm -rf cover; \
+	  docker compose down -v --remove-orphans >/dev/null 2>&1 || true; \
+	  exit $$status; \
+	}; \
+	trap cleanup EXIT INT TERM; \
+	set -e; \
+	echo "==> Bringing up dependencies"; \
+	docker compose up postgres rabbitmq otel-collector -d --wait; \
+	echo "==> Building registry binary (with coverage)"; \
+	go build -cover -o registry ./cmd/registry; \
+	echo "==> Starting registry"; \
+	GOCOVERDIR=$(CURDIR)/cover/integration ./registry >/dev/null 2>&1 & echo $$! > pid.txt; \
+	ready=0; \
+	for i in $$(seq 1 45); do \
+	  if go tool github.com/grpc-ecosystem/grpc-health-probe -addr=localhost:9092 >/dev/null 2>&1; then \
+	    echo "Registry service is ready"; ready=1; break; \
+	  fi; \
+	  echo "Waiting for registry... ($$i/45)"; \
+	  sleep 1; \
+	done; \
+	if [ "$$ready" -ne 1 ]; then echo "Registry service failed to start within 45 seconds"; exit 1; fi; \
+	echo "==> Running unit tests"; \
+	env TEST_ENV=make gotestsum --junitfile=junit-unit.xml --format=testname -- \
+	    -cover ./internal/... -args -test.gocoverdir="$(CURDIR)/cover/unit"; \
+	echo "==> Running integration tests"; \
+	gotestsum --junitfile=junit-integration.xml --format=testname -- \
+	    -v -count=1 -parallel=5 -race -shuffle=on -tags=integration ./integration/...; \
+	echo "==> Stopping registry (to flush coverage)"; \
+	kill -2 "$$(cat pid.txt)"; \
+	wait "$$(cat pid.txt)" 2>/dev/null || true; \
+	rm -f pid.txt; \
+	echo "==> Merging coverage"; \
+	go tool covdata textfmt -i=./cover/unit,./cover/integration -o cover.out; \
+	go tool cover -html=cover.out -o cover.html
 
 # installs gotestsum test helper
 install-gotestsum:
@@ -44,93 +94,9 @@ docker-compose-up-and-log: docker-compose-up
 docker-compose-dependencies-up-and-log: docker-compose-dependencies-up
 	$(MAKE) docker-log
 
-# Prerequisite: PostgreSQL needs to be running
-int-test-up-and-run:
-	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
-	$(MAKE) go-build-and-run; \
-	$(MAKE) int-test-run; status=$$?; \
-	$(MAKE) go-stop-and-remove; exit $$status
-
-# Prerequisite: PostgreSQL and Registry Service need to be running
-int-test-run: install-gotestsum
-	gotestsum --junitfile=junit-integration.xml --format=testname -- -v -count=1 -parallel=5 -race -shuffle=on ./integration/... -tags=integration
-
-# Prerequisite: PostgreSQL needs to be running
-int-test-up-and-run-cover:
-	mkdir -p cover
-
-	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
-	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=cover; \
-	$(MAKE) int-test-run; status=$$?; \
-	$(MAKE) go-stop-and-remove; exit $$status
-
-	go tool covdata textfmt -i=./cover -o cover.out
-	rm -r ./cover
-	go tool cover -html=cover.out
-
-
-# This target is used to run all tests and create a merged coverage report from unit and integration tests
-# Prerequisite: PostgreSQL needs to be running
-all-tests-run-cover: install-gotestsum
-	mkdir -p cover/integration
-	mkdir -p cover/unit
-
-	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
-	$(MAKE) go-build-and-run cover_flag=-cover cover_dir_env=GOCOVERDIR=${CURDIR}/cover/integration; \
-	$(MAKE) int-test-run; status=$$?; \
-	$(MAKE) go-stop-and-remove; exit $$status
-
-	echo "Running unit tests"
-	gotestsum --junitfile=junit-unit.xml --format=testname -- -cover ./internal/... -args -test.gocoverdir="${CURDIR}/cover/unit"
-	echo "Creating coverage report"
-	go tool covdata textfmt -i=./cover/unit,./cover/integration -o cover.out
-	go tool cover --html=cover.out -o cover.html
-	rm -r ./cover
-
-go-build-and-run:
-	go build $(cover_flag) -o registry ./cmd/registry
-	$(cover_dir_env) ./registry 1>/dev/null 2>/dev/null & echo $$! > pid.txt
-	$(MAKE) wait-for-registry
-
-# Waits for the registry service to be ready by polling the gRPC health endpoint
-wait-for-registry:
-	@echo "Waiting for registry service to be ready..."
-	@for i in $$(seq 1 45); do \
-		if go tool github.com/grpc-ecosystem/grpc-health-probe -addr=localhost:9092 2>/dev/null; then \
-			echo "Registry service is ready"; \
-			exit 0; \
-		fi; \
-		echo "Waiting... ($$i/45)"; \
-		sleep 1; \
-	done; \
-	echo "Registry service failed to start within 45 seconds"; \
-	exit 1
-
-go-stop-and-remove:
-	kill -2 `cat pid.txt` || true
-	rm -f pid.txt registry
-
-clean-docker-compose:
-	docker compose down -v && docker compose rm -f -v
-
-.PHONY: clean
-clean:
-	rm -f junit*.xml
-	rm -f cover.out cover.html
-	rm -rf ./cover/
-	rm -f registry
-
-# Runs unit and integration tests with coverage, starts dependency containers, and generates coverage report
-integration-test:
-	# capture the exit status of the tests to ensure we stop and remove the registry service even if tests fail
-	$(MAKE) docker-compose-dependencies-up; \
-	$(MAKE) all-tests-run-cover; status=$$?; \
-	$(MAKE) clean-docker-compose; exit $$status
-
 generate-certs:
 	(cd local/rabbitmq && chmod +x generate-certs.sh && ./generate-certs.sh)
 
-.PHONY: lint
 lint:
 	golangci-lint run -v --fix ./...
 
@@ -153,3 +119,9 @@ helm-install-registry:
 # Uninstalls the registry-service from the local Kubernetes cluster using Helm.
 helm-uninstall-registry:
 	./helm_registry.sh uninstall
+
+clean:
+	rm -f junit-unit.xml junit-integration.xml
+	rm -f cover.out cover.html
+	rm -rf ./cover/
+	rm -f registry pid.txt

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -84,40 +84,48 @@ func (a *Auth) ApplyAuth(ctx context.Context, req *authgrpc.ApplyAuthRequest) (*
 		Status:     authgrpc.AuthStatus_AUTH_STATUS_APPLYING.String(),
 	}
 
-	err := a.validateAuth(auth)
-	if err != nil {
+	if err := a.validateAuth(auth); err != nil {
 		return nil, err
 	}
 
-	err = a.repo.Transaction(ctx, func(ctx context.Context, r repository.Repository) error {
-		err := a.validateActiveTenant(ctx, r, auth.TenantID)
-		if err != nil {
+	err := a.repo.Transaction(ctx, func(ctx context.Context, r repository.Repository) error {
+		if err := a.validateActiveTenant(ctx, r, auth.TenantID); err != nil {
 			slogctx.Error(ctx, "tenant is invalid or not active", "error", err)
 			return err
 		}
 
-		err = r.Create(ctx, auth)
+		existing := &model.Auth{ExternalID: auth.ExternalID}
+		found, err := r.Find(ctx, existing)
 		if err != nil {
-			slogctx.Error(ctx, "failed to create auth", "error", err)
-			var ucErr *repository.UniqueConstraintError
-			if errors.As(err, &ucErr) {
-				slogctx.Info(ctx, AuthAlreadyExistsMsg, "detail", ucErr.Detail)
-				return ErrAuthAlreadyExists
+			slogctx.Error(ctx, SelectAuthErrMsg, "error", err)
+			return ErrAuthSelect
+		}
+
+		if found {
+			slogctx.Info(ctx, "patching an existent auth resource")
+			if _, err := r.Patch(ctx, auth); err != nil {
+				slogctx.Error(ctx, "failed to patch an auth resource", "error", err)
+				return status.Error(codes.Internal, "failed to create auth")
 			}
 
+			return nil
+		}
+
+		if err := r.Create(ctx, auth); err != nil {
+			slogctx.Error(ctx, "failed to create auth", "error", err)
 			return status.Error(codes.Internal, "failed to create auth")
 		}
 
-		err = a.prepareJob(ctx, auth, authgrpc.AuthAction_AUTH_ACTION_APPLY_AUTH.String())
-		if err != nil {
+		if err := a.prepareJob(ctx, auth, authgrpc.AuthAction_AUTH_ACTION_APPLY_AUTH.String()); err != nil {
 			slogctx.Error(ctx, "failed to prepare job", "error", err)
 			return err
 		}
 
 		return nil
 	})
+
 	err = mapError(err)
-	if err != nil && !errors.Is(err, ErrAuthAlreadyExists) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -1,0 +1,294 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	authgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/auth/v1"
+	pb "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
+
+	"github.com/openkcm/registry/internal/model"
+	"github.com/openkcm/registry/internal/repository"
+	"github.com/openkcm/registry/internal/service"
+	"github.com/openkcm/registry/internal/validation"
+)
+
+var (
+	errPatchExploded = errors.New("db exploded")
+	errCreateBoom    = errors.New("boom")
+	errAuthFindBoom  = errors.New("find exploded")
+)
+
+// fakeAuthRepo is a minimal repository.Repository implementation that lets
+// ApplyAuth's transaction body be driven from unit tests.
+//
+// Only the calls made by the ApplyAuth path are meaningfully implemented;
+// the rest satisfy the interface with zero values.
+type fakeAuthRepo struct {
+	tenant *model.Tenant
+	// existingAuth, when non-nil, will be returned from Find(*model.Auth)
+	// with a matching ExternalID, and its content copied into the argument.
+	existingAuth *model.Auth
+
+	// authFindErr is returned from Find when looking up an *model.Auth.
+	authFindErr error
+
+	createErr error
+
+	patchFound bool
+	patchErr   error
+
+	authFindCalled bool
+	patchCalled    bool
+	createCalled   bool
+
+	patched *model.Auth
+	created *model.Auth
+}
+
+func (f *fakeAuthRepo) Transaction(ctx context.Context, txFunc repository.TransactionFunc) error {
+	return txFunc(ctx, f)
+}
+
+func (f *fakeAuthRepo) Find(_ context.Context, resource repository.Resource) (bool, error) {
+	switch r := resource.(type) {
+	case *model.Tenant:
+		if f.tenant == nil || f.tenant.ID != r.ID {
+			return false, nil
+		}
+		*r = *f.tenant
+		return true, nil
+	case *model.Auth:
+		f.authFindCalled = true
+		if f.authFindErr != nil {
+			return false, f.authFindErr
+		}
+		if f.existingAuth == nil || f.existingAuth.ExternalID != r.ExternalID {
+			return false, nil
+		}
+		*r = *f.existingAuth
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (f *fakeAuthRepo) Create(_ context.Context, resource repository.Resource) error {
+	f.createCalled = true
+	if a, ok := resource.(*model.Auth); ok {
+		copied := *a
+		f.created = &copied
+	}
+	return f.createErr
+}
+
+func (f *fakeAuthRepo) Patch(_ context.Context, resource repository.Resource) (bool, error) {
+	f.patchCalled = true
+	if a, ok := resource.(*model.Auth); ok {
+		copied := *a
+		f.patched = &copied
+	}
+	return f.patchFound, f.patchErr
+}
+
+func (f *fakeAuthRepo) List(_ context.Context, _ any, _ repository.Query) error {
+	return nil
+}
+
+func (f *fakeAuthRepo) Delete(_ context.Context, _ repository.Resource) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeAuthRepo) PatchAll(_ context.Context, _ repository.Resource, _ any, _ repository.Query) (int64, error) {
+	return 0, nil
+}
+
+func newTestValidation(t *testing.T) *validation.Validation {
+	t.Helper()
+	v, err := validation.New(validation.Config{
+		Models: []validation.Model{&model.Auth{}, &model.Tenant{}},
+	})
+	require.NoError(t, err)
+	return v
+}
+
+func newActiveTenant() *model.Tenant {
+	return &model.Tenant{
+		ID:     "tenant-1",
+		Region: "eu-1",
+		Status: model.TenantStatus(pb.Status_STATUS_ACTIVE.String()),
+	}
+}
+
+func validApplyAuthRequest() *authgrpc.ApplyAuthRequest {
+	return &authgrpc.ApplyAuthRequest{
+		ExternalId: "auth-1",
+		TenantId:   "tenant-1",
+		Type:       "oidc",
+		Properties: map[string]string{"requiredProperty": "value"},
+	}
+}
+
+func TestApplyAuth_PatchOnExistingResource(t *testing.T) {
+	t.Run("patches when an auth with the same external ID already exists", func(t *testing.T) {
+		// given
+		existing := &model.Auth{
+			ExternalID: "auth-1",
+			TenantID:   "some-other-tenant",
+			Type:       "oidc",
+			Status:     authgrpc.AuthStatus_AUTH_STATUS_APPLIED.String(),
+		}
+		repo := &fakeAuthRepo{
+			tenant:       newActiveTenant(),
+			existingAuth: existing,
+			patchFound:   true,
+		}
+
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, resp.Success)
+
+		assert.True(t, repo.authFindCalled, "Find must be attempted to detect an existing auth")
+		assert.True(t, repo.patchCalled, "Patch must be invoked when the auth already exists")
+		assert.False(t, repo.createCalled, "Create must not be attempted when the auth already exists")
+
+		require.NotNil(t, repo.patched)
+		assert.Equal(t, "auth-1", repo.patched.ExternalID)
+		assert.Equal(t, "tenant-1", repo.patched.TenantID)
+		assert.Equal(t, "oidc", repo.patched.Type)
+		assert.Equal(t, "value", repo.patched.Properties["requiredProperty"])
+		assert.Equal(t, authgrpc.AuthStatus_AUTH_STATUS_APPLYING.String(), repo.patched.Status)
+	})
+
+	t.Run("returns Internal error when Patch fails", func(t *testing.T) {
+		// given
+		repo := &fakeAuthRepo{
+			tenant:       newActiveTenant(),
+			existingAuth: &model.Auth{ExternalID: "auth-1"},
+			patchErr:     errPatchExploded,
+		}
+
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.True(t, repo.patchCalled)
+		assert.False(t, repo.createCalled)
+	})
+
+	t.Run("returns Internal error when the pre-check Find fails", func(t *testing.T) {
+		// given
+		repo := &fakeAuthRepo{
+			tenant:      newActiveTenant(),
+			authFindErr: errAuthFindBoom,
+		}
+
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.False(t, repo.createCalled)
+		assert.False(t, repo.patchCalled)
+	})
+
+	t.Run("returns Internal error when Create fails for a fresh auth", func(t *testing.T) {
+		// given: no existing auth, Create fails.
+		repo := &fakeAuthRepo{
+			tenant:    newActiveTenant(),
+			createErr: errCreateBoom,
+		}
+
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.True(t, repo.authFindCalled)
+		assert.True(t, repo.createCalled)
+		assert.False(t, repo.patchCalled, "Patch must not run when Create is exercised on a fresh auth")
+	})
+}
+
+func TestApplyAuth_InvalidRequest(t *testing.T) {
+	t.Run("returns InvalidArgument when the request fails validation", func(t *testing.T) {
+		// given
+		repo := &fakeAuthRepo{tenant: newActiveTenant()}
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		req := validApplyAuthRequest()
+		req.ExternalId = "" // triggers non-empty constraint on Auth.ExternalID
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), req)
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.False(t, repo.createCalled, "Create must not run when validation fails")
+		assert.False(t, repo.patchCalled)
+	})
+}
+
+func TestApplyAuth_TenantNotActive(t *testing.T) {
+	t.Run("returns FailedPrecondition when linked tenant is not active", func(t *testing.T) {
+		// given
+		blockedTenant := newActiveTenant()
+		blockedTenant.Status = model.TenantStatus(pb.Status_STATUS_BLOCKED.String())
+
+		repo := &fakeAuthRepo{tenant: blockedTenant}
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+		assert.False(t, repo.createCalled)
+		assert.False(t, repo.patchCalled)
+	})
+
+	t.Run("returns NotFound when linked tenant does not exist", func(t *testing.T) {
+		// given
+		repo := &fakeAuthRepo{tenant: nil}
+		auth := service.NewAuthForTest(repo, nil, newTestValidation(t))
+
+		// when
+		resp, err := auth.ApplyAuth(context.Background(), validApplyAuthRequest())
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+		assert.False(t, repo.createCalled)
+		assert.False(t, repo.patchCalled)
+	})
+}

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -1,5 +1,20 @@
 package service
 
+import (
+	"github.com/openkcm/registry/internal/repository"
+	"github.com/openkcm/registry/internal/validation"
+)
+
 var (
 	MapError = mapError
 )
+
+// NewAuthForTest builds an Auth without touching orbital, so that unit tests
+// can drive its behaviour against a fake repository.
+func NewAuthForTest(repo repository.Repository, orbital *Orbital, validation *validation.Validation) *Auth {
+	return &Auth{
+		repo:       repo,
+		orbital:    orbital,
+		validation: validation,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
``` Detailed description of PR; If no description, remove the block.
ApplyAuth now patches an Auth resource if it already exists. Otherwise, it creates a new resource.
```

**Special notes for your reviewer**:
``` If no notes, remove the block.
Makefile is refactored so that we don't get confused which target actually runs tests. Before, we had targets `integration-tests`, `int-*` targets which also referred to integration tests, `all-tests-run-cover` which didn't actually run all tests. This created a lot of confusion. They also failed to run in some scenarios and failed to cleanup resources.
```

**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
ApplyAuth supports PATCH operation on an existing auth resource.
```
