### PR TITLE
fix: make Auth.Properties issuer key required

### DIFF
--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -524,6 +524,7 @@ config:
         spec:
           keys:
           - name: issuer # configure validation constraint for the issuer key in the properties map
+            required: true
             constraints:
               - type: non-empty # defines that the value corresponding of the Issuer key cannot be empty if the key is present
     - id: Tenant.OwnerType # configures validation constraints for the OwnerType field of a Tenant


### PR DESCRIPTION
**Release note**:
``` Release notes; If no release note is required, just write "NONE" within the block.
Make Auth.Properties issuer key required
```