### PR TITLE
make terminate unlink all systems

### DIFF
--- a/integration/tenant_termination_test.go
+++ b/integration/tenant_termination_test.go
@@ -171,6 +171,48 @@ func TestTenantTerminate(t *testing.T) {
 				assert.Len(t, ltResp.Tenants, 1)
 				assert.Equal(t, expStatus, ltResp.Tenants[0].Status)
 			})
+
+			t.Run("tenant is blocked and has linked systems, systems are unlinked", func(t *testing.T) {
+				// given
+				state := model.TenantStatus(tenantgrpc.Status_STATUS_BLOCKED.String())
+				tenant, err := persistTenant(ctx, db, validRandID(), state, time.Now())
+				assert.NoError(t, err)
+				t.Cleanup(func() {
+					err = deleteTenantFromDB(ctx, db, tenant)
+					assert.NoError(t, err)
+				})
+
+				sys := &model.System{
+					ExternalID: validRandID(),
+					Type:       allowedSystemType,
+				}
+				sys.LinkTenant(tenant.ID)
+				err = createSystemInDB(ctx, db, sys)
+				assert.NoError(t, err)
+				t.Cleanup(func() {
+					err = deleteSystemInDB(ctx, db, sys.ExternalID, sys.Type)
+					assert.NoError(t, err)
+				})
+
+				// when
+				actResp, err := subj.TerminateTenant(ctx, &tenantgrpc.TerminateTenantRequest{
+					Id: tenant.ID,
+				})
+
+				// then
+				assert.NoError(t, err)
+				assert.NotNil(t, actResp)
+
+				ltResp, err := listTenants(ctx, subj)
+				assert.NoError(t, err)
+				assert.Len(t, ltResp.Tenants, 1)
+				assert.Equal(t, tenantgrpc.Status_STATUS_TERMINATING, ltResp.Tenants[0].Status)
+
+				actual, err := getSystemFromDB(ctx, db, sys.ExternalID, sys.Type)
+				assert.NoError(t, err)
+				assert.NotNil(t, actual)
+				assert.False(t, actual.IsLinkedToTenant())
+			})
 		})
 	})
 }

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -18,3 +18,12 @@ func NewAuthForTest(repo repository.Repository, orbital *Orbital, validation *va
 		validation: validation,
 	}
 }
+
+// NewTenantForTest builds a Tenant without registering orbital job handlers,
+// so that unit tests can drive its behaviour against a fake repository.
+func NewTenantForTest(repo repository.Repository, validation *validation.Validation) *Tenant {
+	return &Tenant{
+		repo:       repo,
+		validation: validation,
+	}
+}

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	MapError         = mapError
-	UnlinkAllSystems = unlinkAllSystems
+	DetachAllSystems = detachAllSystems
 )
 
 // NewAuthForTest builds an Auth without touching orbital, so that unit tests

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	MapError        = mapError
+	MapError         = mapError
 	UnlinkAllSystems = unlinkAllSystems
 )
 
@@ -35,15 +35,14 @@ func NewTenantForTest(repo repository.Repository, validation *validation.Validat
 // that only exercise code paths which do not reach the repository.
 type NoopRepo struct{}
 
-func (NoopRepo) Create(_ context.Context, _ repository.Resource) error          { return nil }
-func (NoopRepo) List(_ context.Context, _ any, _ repository.Query) error        { return nil }
-func (NoopRepo) Delete(_ context.Context, _ repository.Resource) (bool, error)  { return false, nil }
-func (NoopRepo) Find(_ context.Context, _ repository.Resource) (bool, error)    { return false, nil }
-func (NoopRepo) Patch(_ context.Context, _ repository.Resource) (bool, error)   { return true, nil }
+func (NoopRepo) Create(_ context.Context, _ repository.Resource) error         { return nil }
+func (NoopRepo) List(_ context.Context, _ any, _ repository.Query) error       { return nil }
+func (NoopRepo) Delete(_ context.Context, _ repository.Resource) (bool, error) { return false, nil }
+func (NoopRepo) Find(_ context.Context, _ repository.Resource) (bool, error)   { return false, nil }
+func (NoopRepo) Patch(_ context.Context, _ repository.Resource) (bool, error)  { return true, nil }
 func (NoopRepo) PatchAll(_ context.Context, _ repository.Resource, _ any, _ repository.Query) (int64, error) {
 	return 0, nil
 }
 func (NoopRepo) Transaction(_ context.Context, fn repository.TransactionFunc) error {
 	return fn(context.Background(), NoopRepo{})
 }
-

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -1,12 +1,15 @@
 package service
 
 import (
+	"context"
+
 	"github.com/openkcm/registry/internal/repository"
 	"github.com/openkcm/registry/internal/validation"
 )
 
 var (
-	MapError = mapError
+	MapError        = mapError
+	UnlinkAllSystems = unlinkAllSystems
 )
 
 // NewAuthForTest builds an Auth without touching orbital, so that unit tests
@@ -27,3 +30,20 @@ func NewTenantForTest(repo repository.Repository, validation *validation.Validat
 		validation: validation,
 	}
 }
+
+// NoopRepo is a minimal repository.Repository that does nothing, for use in tests
+// that only exercise code paths which do not reach the repository.
+type NoopRepo struct{}
+
+func (NoopRepo) Create(_ context.Context, _ repository.Resource) error          { return nil }
+func (NoopRepo) List(_ context.Context, _ any, _ repository.Query) error        { return nil }
+func (NoopRepo) Delete(_ context.Context, _ repository.Resource) (bool, error)  { return false, nil }
+func (NoopRepo) Find(_ context.Context, _ repository.Resource) (bool, error)    { return false, nil }
+func (NoopRepo) Patch(_ context.Context, _ repository.Resource) (bool, error)   { return true, nil }
+func (NoopRepo) PatchAll(_ context.Context, _ repository.Resource, _ any, _ repository.Query) (int64, error) {
+	return 0, nil
+}
+func (NoopRepo) Transaction(_ context.Context, fn repository.TransactionFunc) error {
+	return fn(context.Background(), NoopRepo{})
+}
+

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -617,7 +617,9 @@ func (t *Tenant) patchTenant(ctx context.Context, opts patchTenantOpts) error {
 		}
 
 		if opts.validateFn != nil {
-			err = opts.validateFn(tenant)
+			if err = opts.validateFn(tenant); err != nil {
+				return err
+			}
 		}
 
 		if opts.preFn != nil {

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -251,7 +251,7 @@ func (t *Tenant) TerminateTenant(ctx context.Context, in *tenantgrpc.TerminateTe
 	err = t.patchTenant(ctx, patchTenantOpts{
 		id: in.GetId(),
 		preFn: func(ctx context.Context, r repository.Repository, _ *model.Tenant) error {
-			return unlinkAllSystems(ctx, r, in.GetId())
+			return detachAllSystems(ctx, r, in.GetId())
 		},
 		updateFn: func(tenant *model.Tenant) {
 			tenant.SetStatus(model.TenantStatus(tenantgrpc.Status_STATUS_TERMINATING.String()))
@@ -762,14 +762,34 @@ func addLabelsCondition(cond *repository.CompositeKey, validation *validation.Va
 	return nil
 }
 
-// unlinkAllSystems sets TenantID to empty on all Systems linked to the given tenant.
-func unlinkAllSystems(ctx context.Context, r repository.Repository, tenantID string) error {
-	query := repository.NewQuery(&model.System{}).Where(
-		repository.NewCompositeKey().Where(repository.TenantIDField, tenantID),
-	)
+// detachAllSystems releases L1 key claims on all regional systems linked to the given tenant,
+// then clears TenantID on all systems linked to that tenant.
+func detachAllSystems(ctx context.Context, r repository.Repository, tenantID string) error {
+	falseVal := false
+	joinQuery := repository.NewQuery(&model.RegionalSystem{})
+	joinQuery.Joins = []repository.Join{
+		{
+			Resource: &model.System{},
+			OnColumn: repository.IDField,
+			Column:   repository.SystemIDField,
+		},
+	}
+	tenantField := fmt.Sprintf("%s.%s", (&model.System{}).TableName(), repository.TenantIDField)
+	joinQuery.Where(repository.NewCompositeKey().Where(tenantField, tenantID))
+
+	if _, err := r.PatchAll(ctx,
+		&model.RegionalSystem{HasL1KeyClaim: &falseVal},
+		&[]model.RegionalSystem{},
+		*joinQuery,
+	); err != nil {
+		slogctx.Error(ctx, "failed to release L1 key claims during detach", "tenantID", tenantID, "error", err)
+		return ErrSystemUpdate
+	}
 
 	var systems []model.System
-	if err := r.List(ctx, &systems, *query); err != nil {
+	if err := r.List(ctx, &systems, *repository.NewQuery(&model.System{}).Where(
+		repository.NewCompositeKey().Where(repository.TenantIDField, tenantID),
+	)); err != nil {
 		return ErrSystemSelect
 	}
 
@@ -777,7 +797,7 @@ func unlinkAllSystems(ctx context.Context, r repository.Repository, tenantID str
 	for i := range systems {
 		systems[i].TenantID = &emptyTenantID
 		if _, err := r.Patch(ctx, &systems[i]); err != nil {
-			slogctx.Error(ctx, "failed to patch system during unlink", "systemID", systems[i].ID, "error", err)
+			slogctx.Error(ctx, "failed to unlink system during detach", "systemID", systems[i].ID, "error", err)
 			return ErrSystemUpdate
 		}
 	}

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -37,11 +37,13 @@ type (
 	tenantUpdateFn   func(tenant *model.Tenant)
 	tenantValidateFn func(tenant *model.Tenant) error
 	orbitalJobFn     func(ctx context.Context, tenant *model.Tenant) error
+	tenantPreFn      func(ctx context.Context, r repository.Repository, tenant *model.Tenant) error
 
 	patchTenantOpts struct {
 		id            string
 		updateFn      tenantUpdateFn
 		validateFn    tenantValidateFn
+		preFn         tenantPreFn
 		patchAuthOpts patchAuthOpts
 		jobFn         orbitalJobFn
 	}
@@ -246,12 +248,11 @@ func (t *Tenant) TerminateTenant(ctx context.Context, in *tenantgrpc.TerminateTe
 		return nil, err
 	}
 
-	if err := assertNoSystemLinks(ctx, t.repo, in.GetId()); err != nil {
-		return nil, err
-	}
-
 	err = t.patchTenant(ctx, patchTenantOpts{
 		id: in.GetId(),
+		preFn: func(ctx context.Context, r repository.Repository, _ *model.Tenant) error {
+			return unlinkAllSystems(ctx, r, in.GetId())
+		},
 		updateFn: func(tenant *model.Tenant) {
 			tenant.SetStatus(model.TenantStatus(tenantgrpc.Status_STATUS_TERMINATING.String()))
 		},
@@ -617,7 +618,10 @@ func (t *Tenant) patchTenant(ctx context.Context, opts patchTenantOpts) error {
 
 		if opts.validateFn != nil {
 			err = opts.validateFn(tenant)
-			if err != nil {
+		}
+
+		if opts.preFn != nil {
+			if err = opts.preFn(ctx, r, tenant); err != nil {
 				return err
 			}
 		}
@@ -756,24 +760,24 @@ func addLabelsCondition(cond *repository.CompositeKey, validation *validation.Va
 	return nil
 }
 
-// assertNoSystemLinks checks if there are any Systems linked with the Tenant.
-// If records are found for the provided tenantID, it returns an error.
-// Here repository r is passed as a variable to address the scenarios where we will
-// create a new repository from the existing repository for e.g. in the case of transaction.
-func assertNoSystemLinks(ctx context.Context, r repository.Repository, tenantID string) error {
+// unlinkAllSystems sets TenantID to empty on all Systems linked to the given tenant.
+func unlinkAllSystems(ctx context.Context, r repository.Repository, tenantID string) error {
 	query := repository.NewQuery(&model.System{}).Where(
 		repository.NewCompositeKey().Where(repository.TenantIDField, tenantID),
 	)
 
 	var systems []model.System
-
-	err := r.List(ctx, &systems, *query)
-	if err != nil {
+	if err := r.List(ctx, &systems, *query); err != nil {
 		return ErrSystemSelect
 	}
 
-	if len(systems) > 0 {
-		return ErrSystemIsLinkedToTenant
+	emptyTenantID := ""
+	for i := range systems {
+		systems[i].TenantID = &emptyTenantID
+		if _, err := r.Patch(ctx, &systems[i]); err != nil {
+			slogctx.Error(ctx, "failed to patch system during unlink", "systemID", systems[i].ID, "error", err)
+			return ErrSystemUpdate
+		}
 	}
 
 	return nil

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -765,32 +765,30 @@ func addLabelsCondition(cond *repository.CompositeKey, validation *validation.Va
 // detachAllSystems releases L1 key claims on all regional systems linked to the given tenant,
 // then clears TenantID on all systems linked to that tenant.
 func detachAllSystems(ctx context.Context, r repository.Repository, tenantID string) error {
-	falseVal := false
-	joinQuery := repository.NewQuery(&model.RegionalSystem{})
-	joinQuery.Joins = []repository.Join{
-		{
-			Resource: &model.System{},
-			OnColumn: repository.IDField,
-			Column:   repository.SystemIDField,
-		},
-	}
-	tenantField := fmt.Sprintf("%s.%s", (&model.System{}).TableName(), repository.TenantIDField)
-	joinQuery.Where(repository.NewCompositeKey().Where(tenantField, tenantID))
-
-	if _, err := r.PatchAll(ctx,
-		&model.RegionalSystem{HasL1KeyClaim: &falseVal},
-		&[]model.RegionalSystem{},
-		*joinQuery,
-	); err != nil {
-		slogctx.Error(ctx, "failed to release L1 key claims during detach", "tenantID", tenantID, "error", err)
-		return ErrSystemUpdate
-	}
-
 	var systems []model.System
 	if err := r.List(ctx, &systems, *repository.NewQuery(&model.System{}).Where(
 		repository.NewCompositeKey().Where(repository.TenantIDField, tenantID),
 	)); err != nil {
 		return ErrSystemSelect
+	}
+
+	if len(systems) > 0 {
+		systemIDs := make([]string, len(systems))
+		for i, s := range systems {
+			systemIDs[i] = s.ID.String()
+		}
+
+		falseVal := false
+		if _, err := r.PatchAll(ctx,
+			&model.RegionalSystem{HasL1KeyClaim: &falseVal},
+			&[]model.RegionalSystem{},
+			*repository.NewQuery(&model.RegionalSystem{}).Where(
+				repository.NewCompositeKey().Where(repository.SystemIDField, systemIDs),
+			),
+		); err != nil {
+			slogctx.Error(ctx, "failed to release L1 key claims during detach", "tenantID", tenantID, "error", err)
+			return ErrSystemUpdate
+		}
 	}
 
 	emptyTenantID := ""

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -250,8 +250,8 @@ func (t *Tenant) TerminateTenant(ctx context.Context, in *tenantgrpc.TerminateTe
 
 	err = t.patchTenant(ctx, patchTenantOpts{
 		id: in.GetId(),
-		preFn: func(ctx context.Context, r repository.Repository, _ *model.Tenant) error {
-			return detachAllSystems(ctx, r, in.GetId())
+		preFn: func(ctx context.Context, r repository.Repository, tenant *model.Tenant) error {
+			return detachAllSystems(ctx, r, tenant.ID)
 		},
 		updateFn: func(tenant *model.Tenant) {
 			tenant.SetStatus(model.TenantStatus(tenantgrpc.Status_STATUS_TERMINATING.String()))

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -36,7 +36,8 @@ func newTenantTestValidation(t *testing.T) *validation.Validation {
 	return v
 }
 
-func linkedSystem(tenantID string) model.System {
+func linkedSystem() model.System {
+	const tenantID = "t-1"
 	id, _ := uuid.NewV4()
 	tid := tenantID
 	return model.System{ID: id, ExternalID: "sys-1", Type: "application", TenantID: &tid}
@@ -110,7 +111,7 @@ func TestDetachAllSystems(t *testing.T) {
 
 	t.Run("returns ErrSystemUpdate when PatchAll fails", func(t *testing.T) {
 		repo := &fakeDetachRepo{
-			systems:     []model.System{linkedSystem("t-1")},
+			systems:     []model.System{linkedSystem()},
 			patchAllErr: errPatchAllFailed,
 		}
 
@@ -131,7 +132,7 @@ func TestDetachAllSystems(t *testing.T) {
 
 	t.Run("returns ErrSystemUpdate when patching a system fails", func(t *testing.T) {
 		repo := &fakeDetachRepo{
-			systems:  []model.System{linkedSystem("t-1")},
+			systems:  []model.System{linkedSystem()},
 			patchErr: errPatchFailed,
 		}
 
@@ -142,7 +143,7 @@ func TestDetachAllSystems(t *testing.T) {
 	})
 
 	t.Run("calls PatchAll with HasL1KeyClaim=false before unlinking systems", func(t *testing.T) {
-		sys := linkedSystem("t-1")
+		sys := linkedSystem()
 		repo := &fakeDetachRepo{
 			systems: []model.System{sys},
 		}
@@ -158,7 +159,7 @@ func TestDetachAllSystems(t *testing.T) {
 	})
 
 	t.Run("clears TenantID on all linked systems", func(t *testing.T) {
-		sys := linkedSystem("t-1")
+		sys := linkedSystem()
 		repo := &fakeDetachRepo{
 			systems: []model.System{sys},
 		}

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -1,0 +1,40 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	tenantgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
+
+	"github.com/openkcm/registry/internal/model"
+	"github.com/openkcm/registry/internal/service"
+	"github.com/openkcm/registry/internal/validation"
+)
+
+func newTenantTestValidation(t *testing.T) *validation.Validation {
+	t.Helper()
+	v, err := validation.New(validation.Config{
+		Models: []validation.Model{&model.Tenant{}},
+	})
+	require.NoError(t, err)
+	return v
+}
+
+func TestTerminateTenant(t *testing.T) {
+	t.Run("should return InvalidArgument when tenant ID is empty", func(t *testing.T) {
+		subj := service.NewTenantForTest(nil, newTenantTestValidation(t))
+
+		resp, err := subj.TerminateTenant(context.Background(), &tenantgrpc.TerminateTenantRequest{
+			Id: "",
+		})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -19,6 +19,11 @@ import (
 	"github.com/openkcm/registry/internal/validation"
 )
 
+var (
+	errListFailed  = errors.New("db down")
+	errPatchFailed = errors.New("patch failed")
+)
+
 // --- helpers -----------------------------------------------------------------
 
 func newTenantTestValidation(t *testing.T) *validation.Validation {
@@ -40,6 +45,7 @@ func linkedSystem(tenantID string) model.System {
 
 type fakeUnlinkRepo struct {
 	service.NoopRepo
+
 	systems  []model.System
 	listErr  error
 	patchErr error
@@ -90,7 +96,7 @@ func TestUnlinkAllSystems(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns ErrSystemSelect when listing systems fails", func(t *testing.T) {
-		repo := &fakeUnlinkRepo{listErr: errors.New("db down")}
+		repo := &fakeUnlinkRepo{listErr: errListFailed}
 
 		err := service.UnlinkAllSystems(ctx, repo, "t-1")
 
@@ -101,7 +107,7 @@ func TestUnlinkAllSystems(t *testing.T) {
 	t.Run("returns ErrSystemUpdate when patching a system fails", func(t *testing.T) {
 		repo := &fakeUnlinkRepo{
 			systems:  []model.System{linkedSystem("t-1")},
-			patchErr: errors.New("patch failed"),
+			patchErr: errPatchFailed,
 		}
 
 		err := service.UnlinkAllSystems(ctx, repo, "t-1")

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -2,8 +2,10 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -12,9 +14,12 @@ import (
 	tenantgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
 
 	"github.com/openkcm/registry/internal/model"
+	"github.com/openkcm/registry/internal/repository"
 	"github.com/openkcm/registry/internal/service"
 	"github.com/openkcm/registry/internal/validation"
 )
+
+// --- helpers -----------------------------------------------------------------
 
 func newTenantTestValidation(t *testing.T) *validation.Validation {
 	t.Helper()
@@ -24,6 +29,46 @@ func newTenantTestValidation(t *testing.T) *validation.Validation {
 	require.NoError(t, err)
 	return v
 }
+
+func linkedSystem(tenantID string) model.System {
+	id, _ := uuid.NewV4()
+	tid := tenantID
+	return model.System{ID: id, ExternalID: "sys-1", Type: "application", TenantID: &tid}
+}
+
+// --- fake repo for unlinkAllSystems ------------------------------------------
+
+type fakeUnlinkRepo struct {
+	service.NoopRepo
+	systems  []model.System
+	listErr  error
+	patchErr error
+
+	patchedSystems []*model.System
+}
+
+func (f *fakeUnlinkRepo) List(_ context.Context, dest any, _ repository.Query) error {
+	if f.listErr != nil {
+		return f.listErr
+	}
+	if out, ok := dest.(*[]model.System); ok {
+		*out = append(*out, f.systems...)
+	}
+	return nil
+}
+
+func (f *fakeUnlinkRepo) Patch(_ context.Context, resource repository.Resource) (bool, error) {
+	if f.patchErr != nil {
+		return false, f.patchErr
+	}
+	if s, ok := resource.(*model.System); ok {
+		copied := *s
+		f.patchedSystems = append(f.patchedSystems, &copied)
+	}
+	return true, nil
+}
+
+// --- TestTerminateTenant -----------------------------------------------------
 
 func TestTerminateTenant(t *testing.T) {
 	t.Run("should return InvalidArgument when tenant ID is empty", func(t *testing.T) {
@@ -36,5 +81,55 @@ func TestTerminateTenant(t *testing.T) {
 		assert.Nil(t, resp)
 		require.Error(t, err)
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}
+
+// --- TestUnlinkAllSystems ----------------------------------------------------
+
+func TestUnlinkAllSystems(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns ErrSystemSelect when listing systems fails", func(t *testing.T) {
+		repo := &fakeUnlinkRepo{listErr: errors.New("db down")}
+
+		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("returns ErrSystemUpdate when patching a system fails", func(t *testing.T) {
+		repo := &fakeUnlinkRepo{
+			systems:  []model.System{linkedSystem("t-1")},
+			patchErr: errors.New("patch failed"),
+		}
+
+		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("clears TenantID on all linked systems", func(t *testing.T) {
+		sys := linkedSystem("t-1")
+		repo := &fakeUnlinkRepo{
+			systems: []model.System{sys},
+		}
+
+		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+
+		require.NoError(t, err)
+		require.Len(t, repo.patchedSystems, 1)
+		assert.Equal(t, sys.ID, repo.patchedSystems[0].ID)
+		assert.False(t, repo.patchedSystems[0].IsLinkedToTenant())
+	})
+
+	t.Run("succeeds with no-op when no systems are linked", func(t *testing.T) {
+		repo := &fakeUnlinkRepo{}
+
+		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+
+		require.NoError(t, err)
+		assert.Empty(t, repo.patchedSystems)
 	})
 }

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -109,7 +109,10 @@ func TestDetachAllSystems(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns ErrSystemUpdate when PatchAll fails", func(t *testing.T) {
-		repo := &fakeDetachRepo{patchAllErr: errPatchAllFailed}
+		repo := &fakeDetachRepo{
+			systems:     []model.System{linkedSystem("t-1")},
+			patchAllErr: errPatchAllFailed,
+		}
 
 		err := service.DetachAllSystems(ctx, repo, "t-1")
 
@@ -175,6 +178,6 @@ func TestDetachAllSystems(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Empty(t, repo.patchedSystems)
-		assert.Equal(t, 1, repo.patchAllCallCount)
+		assert.Equal(t, 0, repo.patchAllCallCount)
 	})
 }

--- a/internal/service/tenant_test.go
+++ b/internal/service/tenant_test.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	errListFailed  = errors.New("db down")
-	errPatchFailed = errors.New("patch failed")
+	errListFailed     = errors.New("db down")
+	errPatchFailed    = errors.New("patch failed")
+	errPatchAllFailed = errors.New("patch all failed")
 )
 
 // --- helpers -----------------------------------------------------------------
@@ -41,19 +42,22 @@ func linkedSystem(tenantID string) model.System {
 	return model.System{ID: id, ExternalID: "sys-1", Type: "application", TenantID: &tid}
 }
 
-// --- fake repo for unlinkAllSystems ------------------------------------------
+// --- fake repo for detachAllSystems ------------------------------------------
 
-type fakeUnlinkRepo struct {
+type fakeDetachRepo struct {
 	service.NoopRepo
 
-	systems  []model.System
-	listErr  error
-	patchErr error
+	systems     []model.System
+	listErr     error
+	patchErr    error
+	patchAllErr error
 
-	patchedSystems []*model.System
+	patchedSystems    []*model.System
+	patchAllResource  repository.Resource
+	patchAllCallCount int
 }
 
-func (f *fakeUnlinkRepo) List(_ context.Context, dest any, _ repository.Query) error {
+func (f *fakeDetachRepo) List(_ context.Context, dest any, _ repository.Query) error {
 	if f.listErr != nil {
 		return f.listErr
 	}
@@ -63,7 +67,7 @@ func (f *fakeUnlinkRepo) List(_ context.Context, dest any, _ repository.Query) e
 	return nil
 }
 
-func (f *fakeUnlinkRepo) Patch(_ context.Context, resource repository.Resource) (bool, error) {
+func (f *fakeDetachRepo) Patch(_ context.Context, resource repository.Resource) (bool, error) {
 	if f.patchErr != nil {
 		return false, f.patchErr
 	}
@@ -72,6 +76,15 @@ func (f *fakeUnlinkRepo) Patch(_ context.Context, resource repository.Resource) 
 		f.patchedSystems = append(f.patchedSystems, &copied)
 	}
 	return true, nil
+}
+
+func (f *fakeDetachRepo) PatchAll(_ context.Context, resource repository.Resource, _ any, _ repository.Query) (int64, error) {
+	f.patchAllCallCount++
+	f.patchAllResource = resource
+	if f.patchAllErr != nil {
+		return 0, f.patchAllErr
+	}
+	return 0, nil
 }
 
 // --- TestTerminateTenant -----------------------------------------------------
@@ -90,39 +103,64 @@ func TestTerminateTenant(t *testing.T) {
 	})
 }
 
-// --- TestUnlinkAllSystems ----------------------------------------------------
+// --- TestDetachAllSystems ----------------------------------------------------
 
-func TestUnlinkAllSystems(t *testing.T) {
+func TestDetachAllSystems(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("returns ErrSystemSelect when listing systems fails", func(t *testing.T) {
-		repo := &fakeUnlinkRepo{listErr: errListFailed}
+	t.Run("returns ErrSystemUpdate when PatchAll fails", func(t *testing.T) {
+		repo := &fakeDetachRepo{patchAllErr: errPatchAllFailed}
 
-		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+		err := service.DetachAllSystems(ctx, repo, "t-1")
+
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("returns ErrSystemSelect when listing systems fails", func(t *testing.T) {
+		repo := &fakeDetachRepo{listErr: errListFailed}
+
+		err := service.DetachAllSystems(ctx, repo, "t-1")
 
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 	})
 
 	t.Run("returns ErrSystemUpdate when patching a system fails", func(t *testing.T) {
-		repo := &fakeUnlinkRepo{
+		repo := &fakeDetachRepo{
 			systems:  []model.System{linkedSystem("t-1")},
 			patchErr: errPatchFailed,
 		}
 
-		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+		err := service.DetachAllSystems(ctx, repo, "t-1")
 
 		require.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
 	})
 
-	t.Run("clears TenantID on all linked systems", func(t *testing.T) {
+	t.Run("calls PatchAll with HasL1KeyClaim=false before unlinking systems", func(t *testing.T) {
 		sys := linkedSystem("t-1")
-		repo := &fakeUnlinkRepo{
+		repo := &fakeDetachRepo{
 			systems: []model.System{sys},
 		}
 
-		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+		err := service.DetachAllSystems(ctx, repo, "t-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.patchAllCallCount)
+		rs, ok := repo.patchAllResource.(*model.RegionalSystem)
+		require.True(t, ok, "PatchAll resource should be *model.RegionalSystem")
+		require.NotNil(t, rs.HasL1KeyClaim)
+		assert.False(t, *rs.HasL1KeyClaim)
+	})
+
+	t.Run("clears TenantID on all linked systems", func(t *testing.T) {
+		sys := linkedSystem("t-1")
+		repo := &fakeDetachRepo{
+			systems: []model.System{sys},
+		}
+
+		err := service.DetachAllSystems(ctx, repo, "t-1")
 
 		require.NoError(t, err)
 		require.Len(t, repo.patchedSystems, 1)
@@ -131,11 +169,12 @@ func TestUnlinkAllSystems(t *testing.T) {
 	})
 
 	t.Run("succeeds with no-op when no systems are linked", func(t *testing.T) {
-		repo := &fakeUnlinkRepo{}
+		repo := &fakeDetachRepo{}
 
-		err := service.UnlinkAllSystems(ctx, repo, "t-1")
+		err := service.DetachAllSystems(ctx, repo, "t-1")
 
 		require.NoError(t, err)
 		assert.Empty(t, repo.patchedSystems)
+		assert.Equal(t, 1, repo.patchAllCallCount)
 	})
 }


### PR DESCRIPTION
- deleted check for linked systems before termination
- added logic to unlink systems before termination of tenant
- added `tenantPreFn` type and `preFn` field to `patchTenantOpts` - a hook that runs inside the transaction after tenant fetch, before validation. This way we can achieve the unlink as part of one transaction.