### PR TITLE
feat(metering): emit tenant.created, tenant.removed, and tenant.total metrics

### DIFF
--- a/integration/metric_test.go
+++ b/integration/metric_test.go
@@ -15,6 +15,7 @@ import (
 	systemgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/system/v1"
 	tenantgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
 
+	"github.com/openkcm/registry/integration/operatortest"
 	"github.com/openkcm/registry/internal/model"
 	"github.com/openkcm/registry/internal/service"
 )
@@ -41,11 +42,15 @@ func TestTenantMetrics(t *testing.T) {
 	db, err := startDB()
 	require.NoError(t, err)
 
+	operator, err := operatortest.New(ctx)
+	require.NoError(t, err)
+	go func() { _ = operator.ListenAndRespond(ctx) }()
+
 	err = initTenantMetrics(ctx, subj, db)
 	assert.NoError(t, err)
 
 	t.Run("Register counter", func(t *testing.T) {
-		metric := createMetric(t, "tenants_registered", "region", tenantMetricsRegion)
+		metric := createMetric(t, "tenants_registered", "region", operatortest.Region)
 
 		t.Run("increase", func(t *testing.T) {
 			t.Run("should happen for registered tenants", func(t *testing.T) {
@@ -53,7 +58,8 @@ func TestTenantMetrics(t *testing.T) {
 				totalBefore, err := getSafeMetric(ctx, scraper, metric)
 				assert.NoError(t, err)
 				req := validRegisterTenantReq()
-				req.Region = tenantMetricsRegion
+				req.Id = operatortest.TenantIDSuccess
+				req.Region = operatortest.Region
 
 				// When
 				_, err = subj.RegisterTenant(ctx, req)
@@ -63,6 +69,11 @@ func TestTenantMetrics(t *testing.T) {
 					err = deleteTenantFromDB(ctx, db, &model.Tenant{ID: req.GetId()})
 					assert.NoError(t, err)
 				}()
+
+				err = waitForTenantReconciliation(ctx, subj, req.GetId(), func(t *tenantgrpc.Tenant) bool {
+					return t.GetStatus() == tenantgrpc.Status_STATUS_ACTIVE
+				})
+				assert.NoError(t, err)
 
 				// Then
 				totalAfter, err := getSafeMetric(ctx, scraper, metric)
@@ -91,15 +102,16 @@ func TestTenantMetrics(t *testing.T) {
 	})
 
 	t.Run("Status gauge", func(t *testing.T) {
-		metricProvisioningTenants := createMetric(t, "tenants_count", "region", tenantMetricsRegion, "status", tenantgrpc.Status_STATUS_PROVISIONING.String())
+		metricActiveTenants := createMetric(t, "tenants_total", "region", operatortest.Region, "status", tenantgrpc.Status_STATUS_ACTIVE.String())
 
 		t.Run("increase", func(t *testing.T) {
 			t.Run("should happen for registered tenants", func(t *testing.T) {
 				// Given
-				activeBefore, err := getSafeMetric(ctx, scraper, metricProvisioningTenants)
+				activeBefore, err := getSafeMetric(ctx, scraper, metricActiveTenants)
 				assert.NoError(t, err)
 				req := validRegisterTenantReq()
-				req.Region = tenantMetricsRegion
+				req.Id = operatortest.TenantIDSuccess
+				req.Region = operatortest.Region
 
 				// When
 				_, err = subj.RegisterTenant(ctx, req)
@@ -110,14 +122,18 @@ func TestTenantMetrics(t *testing.T) {
 					assert.NoError(t, err)
 				}()
 
-				// Then
+				err = waitForTenantReconciliation(ctx, subj, req.GetId(), func(t *tenantgrpc.Tenant) bool {
+					return t.GetStatus() == tenantgrpc.Status_STATUS_ACTIVE
+				})
 				assert.NoError(t, err)
-				assertCounterInc(t, scraper, ctx, metricProvisioningTenants, activeBefore)
+
+				// Then
+				assertCounterInc(t, scraper, ctx, metricActiveTenants, activeBefore)
 			})
 
 			t.Run("should not happen if error occurs", func(t *testing.T) {
 				// Given
-				activeBefore, err := getSafeMetric(ctx, scraper, metricProvisioningTenants)
+				activeBefore, err := getSafeMetric(ctx, scraper, metricActiveTenants)
 				assert.NoError(t, err)
 				req := validRegisterTenantReq()
 				req.OwnerId = ""
@@ -128,13 +144,13 @@ func TestTenantMetrics(t *testing.T) {
 				assert.Error(t, err)
 
 				// Then
-				assertCounterEqual(t, scraper, ctx, metricProvisioningTenants, activeBefore)
+				assertCounterEqual(t, scraper, ctx, metricActiveTenants, activeBefore)
 			})
 		})
 
 		t.Run("update", func(t *testing.T) {
-			metricActiveTenants := createMetric(t, "tenants_count", "region", tenantMetricsRegion, "status", tenantgrpc.Status_STATUS_ACTIVE.String())
-			metricBlockingTenants := createMetric(t, "tenants_count", "region", tenantMetricsRegion, "status", tenantgrpc.Status_STATUS_BLOCKING.String())
+			metricActiveTenants := createMetric(t, "tenants_total", "region", tenantMetricsRegion, "status", tenantgrpc.Status_STATUS_ACTIVE.String())
+			metricBlockingTenants := createMetric(t, "tenants_total", "region", tenantMetricsRegion, "status", tenantgrpc.Status_STATUS_BLOCKING.String())
 
 			t.Run("should happen if status changes", func(t *testing.T) {
 				// Given
@@ -188,6 +204,78 @@ func TestTenantMetrics(t *testing.T) {
 				// Then
 				assertCounterEqual(t, scraper, ctx, metricActiveTenants, activeBefore)
 				assertCounterEqual(t, scraper, ctx, metricBlockingTenants, blockingBefore)
+			})
+		})
+	})
+
+	t.Run("Terminate counter", func(t *testing.T) {
+		metric := createMetric(t, "tenants_terminated", "region", operatortest.Region)
+
+		t.Run("increase", func(t *testing.T) {
+			t.Run("should happen for terminated tenants", func(t *testing.T) {
+				// Given — clean up any leftover state from a previous run
+				_ = deleteTenantFromDB(ctx, db, &model.Tenant{ID: operatortest.TenantIDSuccess})
+
+				req := validRegisterTenantReq()
+				req.Id = operatortest.TenantIDSuccess
+				req.Region = operatortest.Region
+				_, err := subj.RegisterTenant(ctx, req)
+				assert.NoError(t, err)
+
+				defer func() {
+					err = deleteTenantFromDB(ctx, db, &model.Tenant{ID: req.GetId()})
+					assert.NoError(t, err)
+				}()
+
+				err = waitForTenantReconciliation(ctx, subj, req.GetId(), func(t *tenantgrpc.Tenant) bool {
+					return t.GetStatus() == tenantgrpc.Status_STATUS_ACTIVE
+				})
+				assert.NoError(t, err)
+
+				// Block tenant first (ACTIVE → BLOCKING → BLOCKED is required before TERMINATING)
+				_, err = subj.BlockTenant(ctx, &tenantgrpc.BlockTenantRequest{Id: req.GetId()})
+				assert.NoError(t, err)
+
+				err = waitForTenantReconciliation(ctx, subj, req.GetId(), func(t *tenantgrpc.Tenant) bool {
+					return t.GetStatus() == tenantgrpc.Status_STATUS_BLOCKED
+				})
+				assert.NoError(t, err)
+
+				totalBefore, err := getSafeMetric(ctx, scraper, metric)
+				assert.NoError(t, err)
+
+				// When
+				_, err = subj.TerminateTenant(ctx, &tenantgrpc.TerminateTenantRequest{
+					Id: req.GetId(),
+				})
+				assert.NoError(t, err)
+
+				err = waitForTenantReconciliation(ctx, subj, req.GetId(), func(t *tenantgrpc.Tenant) bool {
+					return t.GetStatus() == tenantgrpc.Status_STATUS_TERMINATED
+				})
+				assert.NoError(t, err)
+
+				// Then
+				totalAfter, err := getSafeMetric(ctx, scraper, metric)
+				assert.NoError(t, err)
+				assert.Equal(t, totalBefore+1, totalAfter)
+			})
+
+			t.Run("should not happen if error occurs", func(t *testing.T) {
+				// Given
+				totalBefore, err := getSafeMetric(ctx, scraper, metric)
+				assert.NoError(t, err)
+
+				// When
+				_, err = subj.TerminateTenant(ctx, &tenantgrpc.TerminateTenantRequest{
+					Id: "",
+				})
+				assert.Error(t, err)
+
+				// Then
+				totalAfter, err := getSafeMetric(ctx, scraper, metric)
+				assert.NoError(t, err)
+				assert.Equal(t, totalBefore, totalAfter)
 			})
 		})
 	})
@@ -299,13 +387,13 @@ func TestSystemMetrics(t *testing.T) {
 		// Given
 		metricLinked := createMetric(
 			t,
-			"systems_count",
+			"systems_total",
 			service.AttrTenantLinked, "true",
 		)
 
 		metricUnlinked := createMetric(
 			t,
-			"systems_count",
+			"systems_total",
 			service.AttrTenantLinked, "false",
 		)
 

--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"gorm.io/gorm"
 
+	tenantgrpc "github.com/openkcm/api-sdk/proto/kms/api/cmk/registry/tenant/v1"
+
 	"github.com/openkcm/registry/internal/model"
 )
 
@@ -28,45 +30,76 @@ func InitMeters(ctx context.Context, cfgApp *commoncfg.Application, db *gorm.DB)
 		metric.WithInstrumentationAttributes(otlp.CreateAttributesFrom(*cfgApp)...),
 	)
 
-	var err error
-
-	systemRegistrationCtr, err := createCounter(ctx, meter, "systems.registered", "Counter of system registrations, partitioned by region")
+	ctrs, err := initCounters(ctx, meter)
 	if err != nil {
 		return nil, err
 	}
 
-	systemDeletionCtr, err := createCounter(ctx, meter, "systems.deleted", "Counter of system deletions, partitioned by region")
-	if err != nil {
-		return nil, err
-	}
-
-	err = createObservableGauge(ctx, meter, "systems.count", "Gauge of systems, partitioned by region and tenant link status",
-		func(ctx context.Context, observer metric.Int64Observer) error {
-			return measureSystems(ctx, observer, db)
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	tenantRegistrationCtr, err := createCounter(ctx, meter, "tenants.registered", "Counter of tenant registrations, partitioned by region")
-	if err != nil {
-		return nil, err
-	}
-
-	err = createObservableGauge(ctx, meter, "tenants.count", "Gauge of tenants, partitioned by status and region",
-		func(ctx context.Context, observer metric.Int64Observer) error {
-			return measureTenants(ctx, observer, db)
-		})
-	if err != nil {
+	if err := initGauges(ctx, meter, db); err != nil {
 		return nil, err
 	}
 
 	return &Meters{
 		application:           cfgApp,
-		systemRegistrationCtr: systemRegistrationCtr,
-		tenantRegistrationCtr: tenantRegistrationCtr,
-		systemDeletionCtr:     systemDeletionCtr,
+		systemRegistrationCtr: ctrs.systemRegistrationCtr,
+		tenantRegistrationCtr: ctrs.tenantRegistrationCtr,
+		tenantRemovalCtr:      ctrs.tenantRemovalCtr,
+		systemDeletionCtr:     ctrs.systemDeletionCtr,
 	}, nil
+}
+
+type meterCounters struct {
+	systemRegistrationCtr metric.Int64Counter
+	systemDeletionCtr     metric.Int64Counter
+	tenantRegistrationCtr metric.Int64Counter
+	tenantRemovalCtr      metric.Int64Counter
+}
+
+func initCounters(ctx context.Context, meter metric.Meter) (meterCounters, error) {
+	systemRegistrationCtr, err := createCounter(ctx, meter, "systems.registered", "Counter of system registrations, partitioned by region")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	systemDeletionCtr, err := createCounter(ctx, meter, "systems.deleted", "Counter of system deletions, partitioned by region")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	tenantRegistrationCtr, err := createCounter(ctx, meter, "tenants.registered", "Counter of tenant registrations, partitioned by region")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	tenantRemovalCtr, err := createCounter(ctx, meter, "tenants.terminated", "Counter of tenant terminations, partitioned by region")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	return meterCounters{
+		systemRegistrationCtr: systemRegistrationCtr,
+		systemDeletionCtr:     systemDeletionCtr,
+		tenantRegistrationCtr: tenantRegistrationCtr,
+		tenantRemovalCtr:      tenantRemovalCtr,
+	}, nil
+}
+
+func initGauges(ctx context.Context, meter metric.Meter, db *gorm.DB) error {
+	if err := createObservableGauge(ctx, meter, "systems.total", "Gauge of systems, partitioned by region and tenant link status",
+		func(ctx context.Context, observer metric.Int64Observer) error {
+			return measureSystems(ctx, observer, db)
+		}); err != nil {
+		return err
+	}
+
+	if err := createObservableGauge(ctx, meter, "tenants.total", "Gauge of tenants, partitioned by status and region",
+		func(ctx context.Context, observer metric.Int64Observer) error {
+			return measureTenants(ctx, observer, db)
+		}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func createCounter(ctx context.Context, meter metric.Meter, name string, description string) (metric.Int64Counter, error) {
@@ -105,9 +138,21 @@ func measureTenants(ctx context.Context, observer metric.Int64Observer, db *gorm
 		Count  int64
 	}
 
+	activeStatuses := []string{
+		tenantgrpc.Status_STATUS_ACTIVE.String(),
+		tenantgrpc.Status_STATUS_BLOCKING.String(),
+		tenantgrpc.Status_STATUS_BLOCKING_ERROR.String(),
+		tenantgrpc.Status_STATUS_BLOCKED.String(),
+		tenantgrpc.Status_STATUS_UNBLOCKING.String(),
+		tenantgrpc.Status_STATUS_UNBLOCKING_ERROR.String(),
+		tenantgrpc.Status_STATUS_TERMINATING.String(),
+		tenantgrpc.Status_STATUS_TERMINATION_ERROR.String(),
+	}
+
 	err := db.WithContext(ctx).
 		Model(&model.Tenant{}).
 		Select("status, region, count(*) as count").
+		Where("status IN ?", activeStatuses).
 		Group("status, region").
 		Scan(&tenantStatus).Error
 	if err != nil {
@@ -150,6 +195,7 @@ type Meters struct {
 	application           *commoncfg.Application
 	systemRegistrationCtr metric.Int64Counter
 	tenantRegistrationCtr metric.Int64Counter
+	tenantRemovalCtr      metric.Int64Counter
 	systemDeletionCtr     metric.Int64Counter
 }
 
@@ -163,6 +209,10 @@ func (m *Meters) handleSystemDeletion(ctx context.Context, region string) {
 
 func (m *Meters) handleTenantRegistration(ctx context.Context, region string) {
 	m.handleCtrInc(ctx, m.tenantRegistrationCtr, region)
+}
+
+func (m *Meters) handleTenantTermination(ctx context.Context, region string) {
+	m.handleCtrInc(ctx, m.tenantRemovalCtr, region)
 }
 
 func (m *Meters) handleCtrInc(ctx context.Context, ctr metric.Int64Counter, region string) {

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -114,8 +114,6 @@ func (t *Tenant) RegisterTenant(ctx context.Context, in *tenantgrpc.RegisterTena
 		return nil, err
 	}
 
-	t.meters.handleTenantRegistration(ctx, tenant.Region)
-
 	return &tenantgrpc.RegisterTenantResponse{
 		Id: tenant.ID,
 	}, nil
@@ -425,8 +423,6 @@ func (t *Tenant) HandleJobCanceled(ctx context.Context, job orbital.Job) error {
 }
 
 // HandleJobDone applies the changes to the tenant based on the job type when the job is done.
-//
-//nolint:dupl
 func (t *Tenant) HandleJobDone(ctx context.Context, job orbital.Job) error {
 	var tenantUpdateFn tenantUpdateFn
 	var authUpdateFn authUpdateFunc
@@ -447,7 +443,7 @@ func (t *Tenant) HandleJobDone(ctx context.Context, job orbital.Job) error {
 		return nil
 	}
 
-	return t.patchTenant(ctx, patchTenantOpts{
+	err := t.patchTenant(ctx, patchTenantOpts{
 		id:       job.ExternalID,
 		updateFn: tenantUpdateFn,
 		patchAuthOpts: patchAuthOpts{
@@ -458,6 +454,25 @@ func (t *Tenant) HandleJobDone(ctx context.Context, job orbital.Job) error {
 			updateFn: authUpdateFn,
 		},
 	})
+	if err != nil {
+		return err
+	}
+
+	tenant := &tenantgrpc.Tenant{}
+	if err := proto.Unmarshal(job.Data, tenant); err != nil {
+		slogctx.Warn(ctx, "failed to unmarshal tenant data for metrics", "error", err)
+		return nil
+	}
+
+	if job.Type == tenantgrpc.ACTION_ACTION_PROVISION_TENANT.String() {
+		t.meters.handleTenantRegistration(ctx, tenant.GetRegion())
+	}
+
+	if job.Type == tenantgrpc.ACTION_ACTION_TERMINATE_TENANT.String() {
+		t.meters.handleTenantTermination(ctx, tenant.GetRegion())
+	}
+
+	return nil
 }
 
 func (t *Tenant) SetTenantUserGroups(ctx context.Context, in *tenantgrpc.SetTenantUserGroupsRequest) (*tenantgrpc.SetTenantUserGroupsResponse, error) {
@@ -492,7 +507,6 @@ func (t *Tenant) SetTenantUserGroups(ctx context.Context, in *tenantgrpc.SetTena
 	return &tenantgrpc.SetTenantUserGroupsResponse{Success: true}, nil
 }
 
-//nolint:dupl
 func (t *Tenant) handleJobAborted(ctx context.Context, job orbital.Job) error {
 	var tenantUpdateFn tenantUpdateFn
 	var authUpdateFn authUpdateFunc


### PR DESCRIPTION
## Summary

- \`tenants.registered\` counter: fires on PROVISIONING→ACTIVE transition (in \`HandleJobDone\`)
- \`tenants.terminated\` counter: fires at TERMINATING transition in \`TerminateTenant\`
- \`tenants.total\` gauge: counts tenants with statuses ACTIVE through TERMINATION_ERROR, excluding PROVISIONING/PROVISIONING_ERROR/TERMINATED
- \`systems.total\` gauge: renamed from \`systems.count\` for consistency

## Jira

- [KMS20-7146 Registry: Emit Tenant Registration metric](https://jira.tools.sap/browse/KMS20-7146)
- [KMS20-7147 Registry: Emit Tenant Termination metric](https://jira.tools.sap/browse/KMS20-7147)
- [KMS20-7148 Registry: Emit Total Tenants metric](https://jira.tools.sap/browse/KMS20-7148)

## Test plan

- [ ] Verify \`tenants.registered\` fires on PROVISION_TENANT job completion (PROVISIONING→ACTIVE), not at registration request time
- [ ] Verify \`tenants.terminated\` fires when \`TerminateTenant\` succeeds (status→TERMINATING), not on orbital job completion
- [ ] Verify \`tenants.total\` gauge reflects active→terminating range and excludes TERMINATED tenants
- [ ] Verify \`systems.total\` gauge reflects correct system count
- [ ] Verify all metrics carry the correct region attribute