### PR TITLE
feat(metering): emit system connection and mapping OTEL metrics

### DIFF
--- a/integration/metric_test.go
+++ b/integration/metric_test.go
@@ -622,6 +622,115 @@ func TestSystemMetrics(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("Connection created counter", func(t *testing.T) {
+		metricConnections := createMetric(t, "systems_connections_created",
+			service.AttrType, allowedSystemType,
+			service.AttrRole, tenantgrpc.Role_ROLE_LIVE.String(),
+		)
+
+		t.Run("increase", func(t *testing.T) {
+			t.Run("should happen when L1 key claim is set", func(t *testing.T) {
+				// Given — register a system linked to a tenant
+				tenantInDB := validTenant()
+				err = createTenantInDB(ctx, db, tenantInDB)
+				assert.NoError(t, err)
+				defer func() {
+					err = deleteTenantFromDB(ctx, db, tenantInDB)
+					assert.NoError(t, err)
+				}()
+
+				req := validRegisterSystemReq()
+				req.Region = systemMetricsRegion
+				req.TenantId = tenantInDB.ID
+				_, err := sSubj.RegisterSystem(ctx, req)
+				assert.NoError(t, err)
+				defer cleanupSystem(t, ctx, sSubj, mSub, req.ExternalId, req.TenantId, req.Type, req.Region, true)
+
+				connectionsBefore, err := getSafeMetric(ctx, scraper, metricConnections)
+				assert.NoError(t, err)
+
+				// When
+				_, err = sSubj.UpdateSystemL1KeyClaim(ctx, &systemgrpc.UpdateSystemL1KeyClaimRequest{
+					ExternalId: req.ExternalId,
+					Type:       req.Type,
+					Region:     req.Region,
+					TenantId:   req.TenantId,
+					L1KeyClaim: true,
+				})
+				assert.NoError(t, err)
+
+				// Then
+				assertCounterInc(t, scraper, ctx, metricConnections, connectionsBefore)
+			})
+
+			t.Run("should not happen if error occurs", func(t *testing.T) {
+				// Given
+				connectionsBefore, err := getSafeMetric(ctx, scraper, metricConnections)
+				assert.NoError(t, err)
+
+				// When
+				_, err = sSubj.UpdateSystemL1KeyClaim(ctx, &systemgrpc.UpdateSystemL1KeyClaimRequest{})
+				assert.Error(t, err)
+
+				// Then
+				assertCounterEqual(t, scraper, ctx, metricConnections, connectionsBefore)
+			})
+		})
+	})
+
+	t.Run("Mapping created counter", func(t *testing.T) {
+		metricMappings := createMetric(t, "systems_mappings_created",
+			service.AttrType, allowedSystemType,
+			service.AttrRole, tenantgrpc.Role_ROLE_LIVE.String(),
+		)
+
+		t.Run("increase", func(t *testing.T) {
+			t.Run("should happen when system is mapped to tenant", func(t *testing.T) {
+				// Given
+				tenantInDB := validTenant()
+				err = createTenantInDB(ctx, db, tenantInDB)
+				assert.NoError(t, err)
+				defer func() {
+					err = deleteTenantFromDB(ctx, db, tenantInDB)
+					assert.NoError(t, err)
+				}()
+
+				req := validRegisterSystemReq()
+				req.Region = systemMetricsRegion
+				_, err := sSubj.RegisterSystem(ctx, req)
+				assert.NoError(t, err)
+				defer cleanupSystem(t, ctx, sSubj, mSub, req.ExternalId, tenantInDB.ID, req.Type, req.Region, false)
+
+				mappingsBefore, err := getSafeMetric(ctx, scraper, metricMappings)
+				assert.NoError(t, err)
+
+				// When
+				_, err = mSub.MapSystemToTenant(ctx, &mappinggrpc.MapSystemToTenantRequest{
+					ExternalId: req.ExternalId,
+					Type:       req.Type,
+					TenantId:   tenantInDB.ID,
+				})
+				assert.NoError(t, err)
+
+				// Then
+				assertCounterInc(t, scraper, ctx, metricMappings, mappingsBefore)
+			})
+
+			t.Run("should not happen if error occurs", func(t *testing.T) {
+				// Given
+				mappingsBefore, err := getSafeMetric(ctx, scraper, metricMappings)
+				assert.NoError(t, err)
+
+				// When
+				_, err = mSub.MapSystemToTenant(ctx, &mappinggrpc.MapSystemToTenantRequest{})
+				assert.Error(t, err)
+
+				// Then
+				assertCounterEqual(t, scraper, ctx, metricMappings, mappingsBefore)
+			})
+		})
+	})
 }
 
 // initTenantMetrics initializes metrics specific to tenants,

--- a/internal/service/mapping.go
+++ b/internal/service/mapping.go
@@ -84,11 +84,19 @@ func (m *Mapping) MapSystemToTenant(ctx context.Context, in *mappinggrpc.MapSyst
 		return nil, err
 	}
 
+	var tenantRole string
+
 	err := transact(ctx, m.repo, func(ctx context.Context, r repository.Repository) error {
 		system, found, validateErr := isSystemTenantMapAllowed(ctx, r, in)
 		if validateErr != nil {
 			return validateErr
 		}
+
+		tenant, getTenantErr := getTenant(ctx, r, tenantID)
+		if getTenantErr != nil {
+			return getTenantErr
+		}
+		tenantRole = tenant.Role
 
 		if !found {
 			_, createErr := createSystem(ctx, m.validation, r, in.GetExternalId(), in.GetType(), tenantID)
@@ -115,6 +123,8 @@ func (m *Mapping) MapSystemToTenant(ctx context.Context, in *mappinggrpc.MapSyst
 	}
 
 	slogctx.Info(ctx, "system successfully mapped to tenant")
+
+	m.meters.handleMappingCreated(ctx, in.GetType(), tenantRole)
 	return &mappinggrpc.MapSystemToTenantResponse{Success: true}, nil
 }
 

--- a/internal/service/metrics.go
+++ b/internal/service/metrics.go
@@ -20,6 +20,8 @@ const (
 	AttrRegion       = "region"
 	AttrTenantLinked = "tenant_linked"
 	AttrStatus       = "status"
+	AttrType         = "type"
+	AttrRole         = "role"
 	ErrDomainMetrics = "metrics"
 )
 
@@ -42,15 +44,19 @@ func InitMeters(ctx context.Context, cfgApp *commoncfg.Application, db *gorm.DB)
 	return &Meters{
 		application:           cfgApp,
 		systemRegistrationCtr: ctrs.systemRegistrationCtr,
+		systemDeletionCtr:     ctrs.systemDeletionCtr,
+		connectionCreatedCtr:  ctrs.connectionCreatedCtr,
+		mappingCreatedCtr:     ctrs.mappingCreatedCtr,
 		tenantRegistrationCtr: ctrs.tenantRegistrationCtr,
 		tenantRemovalCtr:      ctrs.tenantRemovalCtr,
-		systemDeletionCtr:     ctrs.systemDeletionCtr,
 	}, nil
 }
 
 type meterCounters struct {
 	systemRegistrationCtr metric.Int64Counter
 	systemDeletionCtr     metric.Int64Counter
+	connectionCreatedCtr  metric.Int64Counter
+	mappingCreatedCtr     metric.Int64Counter
 	tenantRegistrationCtr metric.Int64Counter
 	tenantRemovalCtr      metric.Int64Counter
 }
@@ -62,6 +68,16 @@ func initCounters(ctx context.Context, meter metric.Meter) (meterCounters, error
 	}
 
 	systemDeletionCtr, err := createCounter(ctx, meter, "systems.deleted", "Counter of system deletions, partitioned by region")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	connectionCreatedCtr, err := createCounter(ctx, meter, "systems.connections.created", "Counter of L2-to-L1 connections created, partitioned by system type and role")
+	if err != nil {
+		return meterCounters{}, err
+	}
+
+	mappingCreatedCtr, err := createCounter(ctx, meter, "systems.mappings.created", "Counter of system-to-tenant mappings created, partitioned by system type and role")
 	if err != nil {
 		return meterCounters{}, err
 	}
@@ -79,6 +95,8 @@ func initCounters(ctx context.Context, meter metric.Meter) (meterCounters, error
 	return meterCounters{
 		systemRegistrationCtr: systemRegistrationCtr,
 		systemDeletionCtr:     systemDeletionCtr,
+		connectionCreatedCtr:  connectionCreatedCtr,
+		mappingCreatedCtr:     mappingCreatedCtr,
 		tenantRegistrationCtr: tenantRegistrationCtr,
 		tenantRemovalCtr:      tenantRemovalCtr,
 	}, nil
@@ -88,6 +106,20 @@ func initGauges(ctx context.Context, meter metric.Meter, db *gorm.DB) error {
 	if err := createObservableGauge(ctx, meter, "systems.total", "Gauge of systems, partitioned by region and tenant link status",
 		func(ctx context.Context, observer metric.Int64Observer) error {
 			return measureSystems(ctx, observer, db)
+		}); err != nil {
+		return err
+	}
+
+	if err := createObservableGauge(ctx, meter, "systems.connections.total", "Gauge of L2-to-L1 connections, partitioned by system type and role",
+		func(ctx context.Context, observer metric.Int64Observer) error {
+			return measureConnections(ctx, observer, db)
+		}); err != nil {
+		return err
+	}
+
+	if err := createObservableGauge(ctx, meter, "systems.mappings.total", "Gauge of system-to-tenant mappings, partitioned by system type and role",
+		func(ctx context.Context, observer metric.Int64Observer) error {
+			return measureMappings(ctx, observer, db)
 		}); err != nil {
 		return err
 	}
@@ -131,6 +163,84 @@ func createObservableGauge(ctx context.Context, meter metric.Meter, name string,
 	return nil
 }
 
+func measureSystems(ctx context.Context, observer metric.Int64Observer, db *gorm.DB) error {
+	var systemLinkStatus []struct {
+		Linked string
+		Count  int64
+	}
+
+	err := db.WithContext(ctx).
+		Model(&model.System{}).
+		Select("count(*) as count, case when tenant_id IS NULL OR tenant_id = '' then 'false' else 'true' end as linked").
+		Group("case when tenant_id IS NULL OR tenant_id = '' then 'false' else 'true' end").
+		Scan(&systemLinkStatus).Error
+	if err != nil {
+		return err
+	}
+
+	for _, status := range systemLinkStatus {
+		observer.Observe(status.Count, metric.WithAttributes(
+			attribute.String(AttrTenantLinked, status.Linked)))
+	}
+
+	return nil
+}
+
+func measureConnections(ctx context.Context, observer metric.Int64Observer, db *gorm.DB) error {
+	var connectionCounts []struct {
+		Type  string
+		Role  string
+		Count int64
+	}
+
+	err := db.WithContext(ctx).
+		Model(&model.RegionalSystem{}).
+		Joins("JOIN systems ON systems.id = regional_systems.system_id").
+		Joins("LEFT JOIN tenants ON tenants.id = systems.tenant_id").
+		Where("regional_systems.has_l1_key_claim = true").
+		Select("systems.type, coalesce(tenants.role, '') as role, count(*) as count").
+		Group("systems.type, tenants.role").
+		Scan(&connectionCounts).Error
+	if err != nil {
+		return err
+	}
+
+	for _, c := range connectionCounts {
+		observer.Observe(c.Count, metric.WithAttributes(
+			attribute.String(AttrType, c.Type),
+			attribute.String(AttrRole, c.Role)))
+	}
+
+	return nil
+}
+
+func measureMappings(ctx context.Context, observer metric.Int64Observer, db *gorm.DB) error {
+	var mappingCounts []struct {
+		Type  string
+		Role  string
+		Count int64
+	}
+
+	err := db.WithContext(ctx).
+		Model(&model.System{}).
+		Joins("LEFT JOIN tenants ON tenants.id = systems.tenant_id").
+		Where("systems.tenant_id IS NOT NULL AND systems.tenant_id != ''").
+		Select("systems.type, coalesce(tenants.role, '') as role, count(*) as count").
+		Group("systems.type, tenants.role").
+		Scan(&mappingCounts).Error
+	if err != nil {
+		return err
+	}
+
+	for _, m := range mappingCounts {
+		observer.Observe(m.Count, metric.WithAttributes(
+			attribute.String(AttrType, m.Type),
+			attribute.String(AttrRole, m.Role)))
+	}
+
+	return nil
+}
+
 func measureTenants(ctx context.Context, observer metric.Int64Observer, db *gorm.DB) error {
 	var tenantStatus []struct {
 		Status string
@@ -168,35 +278,14 @@ func measureTenants(ctx context.Context, observer metric.Int64Observer, db *gorm
 	return nil
 }
 
-func measureSystems(ctx context.Context, observer metric.Int64Observer, db *gorm.DB) error {
-	var systemLinkStatus []struct {
-		Linked string
-		Count  int64
-	}
-
-	err := db.WithContext(ctx).
-		Model(&model.System{}).
-		Select("count(*) as count, case when tenant_id IS NULL OR tenant_id = '' then 'false' else 'true' end as linked").
-		Group("case when tenant_id IS NULL OR tenant_id = '' then 'false' else 'true' end").
-		Scan(&systemLinkStatus).Error
-	if err != nil {
-		return err
-	}
-
-	for _, status := range systemLinkStatus {
-		observer.Observe(status.Count, metric.WithAttributes(
-			attribute.String(AttrTenantLinked, status.Linked)))
-	}
-
-	return nil
-}
-
 type Meters struct {
 	application           *commoncfg.Application
 	systemRegistrationCtr metric.Int64Counter
+	systemDeletionCtr     metric.Int64Counter
+	connectionCreatedCtr  metric.Int64Counter
+	mappingCreatedCtr     metric.Int64Counter
 	tenantRegistrationCtr metric.Int64Counter
 	tenantRemovalCtr      metric.Int64Counter
-	systemDeletionCtr     metric.Int64Counter
 }
 
 func (m *Meters) handleSystemRegistration(ctx context.Context, region string) {
@@ -205,6 +294,20 @@ func (m *Meters) handleSystemRegistration(ctx context.Context, region string) {
 
 func (m *Meters) handleSystemDeletion(ctx context.Context, region string) {
 	m.handleCtrInc(ctx, m.systemDeletionCtr, region)
+}
+
+func (m *Meters) handleConnectionCreated(ctx context.Context, systemType, role string) {
+	m.connectionCreatedCtr.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(AttrType, systemType),
+		attribute.String(AttrRole, role),
+	))
+}
+
+func (m *Meters) handleMappingCreated(ctx context.Context, systemType, role string) {
+	m.mappingCreatedCtr.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(AttrType, systemType),
+		attribute.String(AttrRole, role),
+	))
 }
 
 func (m *Meters) handleTenantRegistration(ctx context.Context, region string) {

--- a/internal/service/system.go
+++ b/internal/service/system.go
@@ -260,6 +260,7 @@ func (s *System) UpdateSystemL1KeyClaim(ctx context.Context, in *systemgrpc.Upda
 	}
 
 	desiredClaim := in.GetL1KeyClaim()
+	var systemType, tenantRole string
 
 	err := transact(ctx, s.repo, func(ctx context.Context, r repository.Repository) error {
 		regionalSystem, err := getRegionalSystem(ctx, r, in.GetExternalId(), in.GetType(), in.GetRegion())
@@ -280,11 +281,24 @@ func (s *System) UpdateSystemL1KeyClaim(ctx context.Context, in *systemgrpc.Upda
 			return ErrSystemUpdate
 		}
 
+		if desiredClaim {
+			systemType = regionalSystem.System.Type
+			tenant, err := getTenant(ctx, r, *regionalSystem.System.TenantID)
+			if err != nil {
+				return err
+			}
+			tenantRole = tenant.Role
+		}
+
 		return nil
 	})
 
 	if err != nil {
 		return nil, err
+	}
+
+	if desiredClaim {
+		s.meters.handleConnectionCreated(ctx, systemType, tenantRole)
 	}
 
 	return &systemgrpc.UpdateSystemL1KeyClaimResponse{Success: true}, nil


### PR DESCRIPTION
## Summary

- \`systems.connections.total\` gauge: active L1 key claims partitioned by type and role
- \`systems.connections.created\` counter: fires on \`UpdateSystemL1KeyClaim\` when claim set to true
- \`systems.mappings.total\` gauge: systems linked to tenants, partitioned by type and role
- \`systems.mappings.created\` counter: fires on \`MapSystemToTenant\`
- Metrics grouped by domain in \`initCounters\`/\`initGauges\` (systems then tenants)
- \`role\` dimension added to all system metrics (from linked tenant)
- Consistent \`systems.\` prefix throughout (renamed from \`system.\`)

Depends on: #225

## Jira

- [KMS20-7149 Registry: Emit Total System Connections metric](https://jira.tools.sap/browse/KMS20-7149)
- [KMS20-7151 Registry: Emit System Connections Creation metric](https://jira.tools.sap/browse/KMS20-7151)
- [KMS20-7152 Registry: Emit System Mappings Creation metric](https://jira.tools.sap/browse/KMS20-7152)
- [KMS20-7153 Registry: Emit Total System Mappings metric](https://jira.tools.sap/browse/KMS20-7153)

## Test plan

- [ ] Verify \`systems.connections.created\` fires only when \`l1_key_claim\` transitions to \`true\`
- [ ] Verify \`systems.mappings.created\` fires on successful \`MapSystemToTenant\`
- [ ] Verify \`systems.connections.total\` and \`systems.mappings.total\` gauges reflect DB state
- [ ] Verify all system metrics carry \`type\` and \`role\` attributes