### PR TITLE
fix: disable exhaustruct_v5 linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - contextcheck
     - depguard
     - exhaustruct
+    - exhaustruct_v5
     - funlen
     - ginkgolinter
     - gochecknoglobals

--- a/integration/tenant_test.go
+++ b/integration/tenant_test.go
@@ -170,6 +170,7 @@ func TestTenantValidation(t *testing.T) {
 				{
 					name: "only id filter is provided",
 					request: &tenantgrpc.ListTenantsRequest{
+						//nolint:staticcheck
 						Id: validRandID(),
 					},
 				},
@@ -208,6 +209,7 @@ func TestTenantValidation(t *testing.T) {
 				{
 					name: "all filter are provided",
 					request: &tenantgrpc.ListTenantsRequest{
+						//nolint:staticcheck
 						Id:        validRandID(),
 						Name:      "some-name",
 						Region:    "region",


### PR DESCRIPTION
To address failing workflows like https://github.com/openkcm/registry/actions/runs/32823662333/job/97726964195?pr=222